### PR TITLE
[CI] update CI configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  create:
+    tags:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -10,14 +14,21 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
+          - '1.3'
+          - '1'
           - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-          - x86
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:
+          - os: windows-latest
+            version: '1'
+            arch: x64
+          - os: macOS-latest
+            version: '1'
+            arch: x64
+          - os: ubuntu-latest
+            version: '1'
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
- set lower Julia version to 1.3 (it seems that NiLang is only compatible with Julia 1.3)
- use the latest Julia 1.x version (currently is equivalent to 1.6)
- add windows and macOS platform for Julia 1

Reduce CI workload:
  - only run one x86 task
  - don't run "duplicated" CI on push commit for PR