### PR TITLE
[WIP] Performance Gap Between dot & idot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ authors = ["JieLi"]
 version = "0.1.0"
 
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -14,6 +14,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,12 @@ uuid = "b3c78db8-5351-4c94-92cb-e6a7a02f3abe"
 authors = ["JieLi"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
 [compat]
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,22 @@ authors = ["JieLi"]
 version = "0.1.0"
 
 [deps]
+BenchmarkPlots = "ab8c0f59-4072-4e0d-8f91-a91e1495eb26"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 
 [compat]
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+BenchmarkPlots = "ab8c0f59-4072-4e0d-8f91-a91e1495eb26"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "ForwardDiff"]
+test = ["Test", "Random", "ForwardDiff", "BenchmarkTools", "BenchmarkPlots", "StatsPlots"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["JieLi"]
 version = "0.1.0"
 
 [deps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -15,6 +14,7 @@ julia = "1"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "ForwardDiff"]

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,10 +1,9 @@
 module NiSparseArrays
 
-using LinearAlgebra: eltype
-using LinearAlgebra
-using NiLang
-using SparseArrays: SparseMatrixCSC, AbstractSparseMatrix, nonzeros, rowvals, nzrange
+using LinearAlgebra, SparseArrays
+using NiLang, ForwardDiff
+using NiLang.AD 
 
 include("linalg.jl")
-
+include("sparsegrad.jl")
 end

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,5 +1,6 @@
 module NiSparseArrays
 
+using LinearAlgebra: eltype, length
 using LinearAlgebra, SparseArrays
 using NiLang
 using NiLang.AD 

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,5 +1,10 @@
 module NiSparseArrays
 
-# Write your package code here.
+using LinearAlgebra: eltype
+using LinearAlgebra
+using NiLang
+using SparseArrays: SparseMatrixCSC, AbstractSparseMatrix, nonzeros, rowvals, nzrange
+
+include("linalg.jl")
 
 end

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,7 +1,7 @@
 module NiSparseArrays
 
 using LinearAlgebra, SparseArrays
-using NiLang, ForwardDiff
+using NiLang
 using NiLang.AD 
 
 include("linalg.jl")

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -49,33 +49,3 @@ for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
     end
 end
 
-# this is an implementation with tmp variables
-# worser performance than no alias version above in benchmark results
-
-# for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
-#     @eval @i function imult!(C::StridedVecOrMat, xA::$T{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
-#         @safe size(xA.parent, 2) == size(C, 1) || throw(DimensionMismatch())
-#         @safe size(xA.parent, 1) == size(B, 1) || throw(DimensionMismatch())
-#         @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
-#         if (β != 1, ~)
-#             @safe error("only β = 1 is supported, got β = $(β).")
-#         end
-#         @invcheckoff for k in 1:size(C, 2)
-#             @inbounds for col in 1:size(xA.parent, 2)
-#                 @routine begin
-#                 tmp ← zero(eltype(C))
-#                 for j in nzrange(xA.parent, col)
-#                     @routine begin
-#                     anc2 ← zero(eltype(xA))
-#                     anc2 += $t(xA.parent.nzval[j])
-#                     end
-#                     tmp += anc2*B[xA.parent.rowval[j],k]
-#                     ~@routine
-#                 end
-#                 C[col,k] += tmp * α
-#                 end
-#                 ~@routine
-#             end
-#         end
-#     end
-# end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -4,287 +4,42 @@ const AdjOrTransDenseMatrix = Union{DenseMatrixUnion,Adjoint{<:Any,<:DenseMatrix
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseInputVecOrMat = Union{AdjOrTransDenseMatrix, StridedVector}
 
-
-@i function imul!(C::StridedVecOrMat, A::AbstractSparseMatrix, B::DenseInputVecOrMat, α::Number, β::Number) 
-    @safe size(A, 2) == size(B, 1) || throw(DimensionMismatch())
-    @safe size(A, 1) == size(C, 1) || throw(DimensionMismatch())
-    @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
-    if (β != 1, ~)
-        @safe error("only β = 1 is supported, got β = $(β).")
-    end
-    # Here, we close the reversibility check inside the loop to increase performance
-    @invcheckoff for k = 1:size(C, 2)
-        @inbounds for col = 1:size(A, 2)
-            αxj ← zero(eltype(B))
-            αxj += B[col,k] * α
-            for j = nzrange(A, col)
-                C[A.rowval[j], k] += A.nzval[j]*αxj
-            end
-            αxj -= B[col,k] * α
-            αxj → zero(eltype(B))
-        end
-    end
-end
-
-
-
-@i function imul!(C::StridedVecOrMat, xA::Adjoint{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
-        @safe size(xA.parent, 2) == size(C, 1) || throw(DimensionMismatch())
-        @safe size(xA.parent, 1) == size(B, 1) || throw(DimensionMismatch())
-        @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
-        if (β != 1, ~)
-            @safe error("only β = 1 is supported, got β = $(β).")
-        end
-        @invcheckoff for k in 1:size(C, 2)
-            @inbounds for col in 1:size(xA.parent, 2)
-                    for j in nzrange(xA.parent, col)
-                    anc1 ← zero(eltype(xA))
-                    anc1 += (xA.parent.nzval[j])'
-                    C[col,k] += anc1*B[xA.parent.rowval[j], k]
-                    anc1 -= (xA.parent.nzval[j])'
-                    anc1 → zero(eltype(xA))
-                end
-            end
-        end
-    end
-
-
-@i function imul!(C::StridedVecOrMat, X::DenseMatrixUnion, A::AbstractSparseMatrix, α::Number, β::Number)
-    @safe size(X, 2) == size(A, 1) || throw(DimensionMismatch())
-    @safe size(X, 1) == size(C, 1) || throw(DimensionMismatch())
-    @safe size(A, 2) == size(C, 2) || throw(DimensionMismatch())
-    if (β != 1, ~)
-        @safe error("only β = 1 is supported, got β = $(β).")
-    end
-    @invcheckoff for col in 1:size(A, 2)
-        @inbounds for k in nzrange(A, col)
-            @simd for multivec_row in 1:size(X,1)
-                C[multivec_row, col] += X[multivec_row, A.rowval[k]]*A.nzval[k]*α
-            end
-        end
-    end
-end
-
-# @i function imul!(C::StridedVecOrMat, X::Adjoint{<:Any,<:DenseMatrixUnion}, A::AbstractSparseMatrix, α::Number, β::Number)
-#     @safe size(X, 2) == size(A, 1) || throw(DimensionMismatch())
-#     @safe size(X, 1) == size(C, 1) || throw(DimensionMismatch())
-#     @safe size(A, 2) == size(C, 2) || throw(DimensionMismatch())
-#     if (β != 1, ~)
-#         @safe error("only β = 1 is supported, got β = $(β).")
-#     end
-#     @invcheckoff for multivec_row in 1:size(X, 1)
-#         for col in 1:size(A, 2)
-#             @inbounds for k in nzrange(A, col)
-#                 C[multivec_row, col] += X[multivec_row, A.rowval[k]]*A.nzval[k]*α
-#             end
-#         end
-#     end
-# end
-
-# this is a better version 
-@i function imul!(C::StridedVecOrMat, X::Adjoint{<:Any,<:DenseMatrixUnion}, A::AbstractSparseMatrix, α::Number, β::Number)
-    @safe size(X.parent, 1) == size(A, 1) || throw(DimensionMismatch())
-    @safe size(X.parent, 2) == size(C, 1) || throw(DimensionMismatch())
-    @safe size(A, 2) == size(C, 2) || throw(DimensionMismatch())
-    if (β != 1, ~)
-        @safe error("only β = 1 is supported, got β = $(β).")
-    end
-    @invcheckoff for multivec_row in 1:size(X.parent, 2)
-        for col in 1:size(A, 2)
-            @inbounds for k in nzrange(A, col)
-                C[multivec_row, col] += X.parent[A.rowval[k], multivec_row]*A.nzval[k]*α
-            end
-        end
-    end
-end
-
-@i function imul!(C::StridedVecOrMat, X::DenseMatrixUnion, xA::Adjoint{<:Any,<:AbstractSparseMatrix}, α::Number, β::Number)
-    @safe size(X, 2) == size(xA.parent, 2) || throw(DimensionMismatch())
-    @safe size(X, 1) == size(C, 1) || throw(DimensionMismatch())
-    @safe size(xA.parent, 1) == size(C, 2) || throw(DimensionMismatch())
-    if (β != 1, ~)
-        @safe error("only β = 1 is supported, got β = $(β).")
-    end
-    @invcheckoff for col in 1:size(xA.parent, 2)
-        @inbounds for k in nzrange(xA.parent, col)
-                        anc1 ← zero(eltype(xA.parent))
-                        anc1 += (xA.parent.nzval[k])'
-            @simd for multivec_row in 1:size(X,1)
-                C[multivec_row, xA.parent.rowval[k]] += X[multivec_row, col]*anc1*α
-            end
-            anc1 -= (xA.parent.nzval[k])'
-            anc1 → zero(eltype(xA.parent))
-        end
-    end
-end
-
-@i function idot(r::T, A::SparseMatrixCSC{T},B::SparseMatrixCSC{T}) where {T}
-    @routine @invcheckoff begin
-        (m, n) ← size(A)
-        branch_keeper ← zeros(Bool, 2*m)
-    end
-    @safe size(B) == (m,n) || throw(DimensionMismatch("matrices must have the same dimensions"))
-    @invcheckoff @inbounds for j = 1:n
-        @routine begin
-            ia1 ← A.colptr[j]
-            ib1 ← B.colptr[j]
-            ia2 ← A.colptr[j+1]
-            ib2 ← B.colptr[j+1]
-            ia ← ia1
-            ib ← ib1
-        end
-        @inbounds for i=1:ia2-ia1+ib2-ib1-1
-            ra ← A.rowval[ia]
-            rb ← B.rowval[ib]
-            if (ra == rb, ~)
-                r += A.nzval[ia]' * B.nzval[ib]
-            end
-            ## b move -> true, a move -> false
-            branch_keeper[i] ⊻= @const ia == ia2-1 || (ib != ib2-1 && ra > rb)
-            ra → A.rowval[ia]
-            rb → B.rowval[ib]
-            if (branch_keeper[i], ~)
-                INC(ib)
-            else
-                INC(ia)
-            end
-        end
-        ~@inbounds for i=1:ia2-ia1+ib2-ib1-1
-            ## b move -> true, a move -> false
-            branch_keeper[i] ⊻= @const ia == ia2-1 || (ib != ib2-1 && A.rowval[ia] > B.rowval[ib])
-            if (branch_keeper[i], ~)
-                INC(ib)
-            else
-                INC(ia)
-            end
-        end
-        ~@routine
-    end
-    ~@routine
-end
-
-# function dot(A::AbstractSparseMatrixCSC{T1,S1},B::AbstractSparseMatrixCSC{T2,S2}) where {T1,T2,S1,S2}
-#     # A and B should be the same size
-#     m, n = size(A)
-#     size(B) == (m,n) || throw(DimensionMismatch("matrices must have the same dimensions"))
-#     r = dot(zero(T1), zero(T2))
-#     # sparse vector dot iterating by columns in A
-#     @inbounds for j = 1:n
-#         # get nonzero element in A[:,j]/B[:,j] with row idx ra/rb 
-#         ia = getcolptr(A)[j]; ia_nxt = getcolptr(A)[j+1]
-#         ib = getcolptr(B)[j]; ib_nxt = getcolptr(B)[j+1]
-#         if ia < ia_nxt && ib < ib_nxt
-#             ra = rowvals(A)[ia]; rb = rowvals(B)[ib]
-#             # iteration in A[:,j]/B[:,j]
-#             while true
-#                 if ra < rb # match false samller ra
-#                     ia += oneunit(S1)
-#                     ia < ia_nxt || break
-#                     ra = rowvals(A)[ia] # update ra bigger
-#                 elseif ra > rb # match false sammler rb
-#                     ib += oneunit(S2)
-#                     ib < ib_nxt || break
-#                     rb = rowvals(B)[ib] # update rb bigger
-#                 else # ra == rb
-#                     r += dot(nonzeros(A)[ia], nonzeros(B)[ib]) # equals to A.nzval[ia]' * B.nzval[ib]
-#                     ia += oneunit(S1); ib += oneunit(S2)
-#                     ia < ia_nxt && ib < ib_nxt || break
-#                     ra = rowvals(A)[ia]; rb = rowvals(B)[ib] # update next ra and rb
-#                 end
-#             end
-#         end
-#     end
-#     return r
-# end
-
-# strange result but I couldn't correct
-@i function idot!(r, x::AbstractVector, A::AbstractSparseMatrix, y::AbstractVector) 
+@i function idotxA(r, x::SparseVector, A::AbstractSparseMatrix{T1}, y::SparseVector{T2}) where {T1, T2}
     @safe length(x) == size(A, 1) || throw(DimensionMismatch())
     @safe length(y) == size(A, 2) || throw(DimensionMismatch())
 
-    @inbounds for col in size(A, 2)
-        for k in nzrange(A, col)
-            r += (x[A.rowval[k]])' * A.nzval[k] * y[col]
+    @invcheckoff @inbounds for (yi, yv) in zip(y.nzind, y.nzval)
+        for (xi, xv) in  zip(x.nzind, x.nzval)
+            for k in nzrange(A, yi)
+                if A.rowval[k] == xi
+                    @routine begin
+                        anc ← zero(promote_type(T1, T2))
+                        anc += A.nzval[k] * yv
+                    end
+                    r += xv' * anc
+                    ~@routine
+                end
+            end
         end
     end
 end 
 
-# a simple version of Gustavson matrix algorithms
-function i_spmatmul(A::SparseMatrixCSC{Tv, Ti}, B::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}
-    mA, nA = size(A)
-    nB = size(B, 2)
-    nA == size(B, 1) || throw(DimensionMismatch())
+@i function idotAx(r, x::SparseVector, A::AbstractSparseMatrix{T1}, y::SparseVector{T2}) where {T1, T2}
+    @safe length(x) == size(A, 1) || throw(DimensionMismatch())
+    @safe length(y) == size(A, 2) || throw(DimensionMismatch())
 
-    # use mA*nB as nonzeros size of C would be ok, upper bound
-    # we may consider estimate a better bound later
-    nnzC = mA*nB
-    colptrC = Vector{Ti}(undef, nB+1)
-    rowvalC = Vector{Ti}(undef, nnzC)
-    nzvalC = Vector{Tv}(undef, nnzC)
-
-    @inbounds begin
-        ip = 1 #colptr index for C 
-        xb = fill(false, mA) #bool column of C in iteration
-        for i in 1:nB
-            colptrC[i] = ip
-            # update ip for next column in C
-            ip = i_spcolmul!(rowvalC, nzvalC, xb, i, ip, A, B)
-        end
-        colptrC[nB+1] = ip
-    end
-    # delete surplus zeros in C
-    resize!(rowvalC, ip - 1)
-    resize!(nzvalC, ip - 1)
-
-    # construct C as SparseMatrixCSC format
-    C = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
-    C
-end
-
-function i_spcolmul!(rowvalC, nzvalC, xb, i, ip, A, B)
-    rowvalA = rowvals(A); nzvalA = nonzeros(A)
-    rowvalB = rowvals(B); nzvalB = nonzeros(B)
-    mA = size(A, 1)
-    ip0 = ip
-    k0 = ip - 1 
-    @inbounds begin
-        for jp in nzrange(B, i) # nz address of B[:,i]
-            nzB = nzvalB[jp]
-            # row index for nzB -> select A[:,j] do nzB*A[:,j]
-            j = rowvalB[jp] 
-            for kp in nzrange(A, j)
-                nzC = nzvalA[kp] * nzB
-                k = rowvalA[kp] # nz row index
-                if xb[k]
-                    # nzvalC saved not continous
-                    # xv used in original Gustavson algorithm
-                    nzvalC[k+k0] += nzC # update C's column
-                else
-                    # nzvalC saved not continous
-                    nzvalC[k+k0] = nzC # initial C's column
-                    xb[k] = true
-                    rowvalC[ip] = k
-                    ip += 1
-                end
-            end
-        end
-        if ip > ip0 # add new nzvals or not
-            for k = 1:mA
-                if xb[k]
-                    xb[k] = false
-                    rowvalC[ip0] = k
-                    nzvalC[ip0] = nzvalC[k+k0] # save it in continous memory
-                    ip0 += 1
+    @invcheckoff @inbounds for (yi, yv) in zip(y.nzind, y.nzval)
+        for k in nzrange(A, yi)
+            for (xi, xv) in  zip(x.nzind, x.nzval)
+                if A.rowval[k] == xi
+                    @routine begin
+                        anc ← zero(promote_type(T1, T2))
+                        anc += A.nzval[k] * yv
+                    end
+                    r += xv' * anc
+                    ~@routine
                 end
             end
         end
     end
-    ip
-end
-
-function i_estimate_mulsize(m::Integer, nnzA::Integer, n::Integer, nnzB::Integer, k::Integer)
-    # may be seperate into serveral steps in NiLang
-    p = (nnzA / (m * n)) * (nnzB / (n * k)) 
-    # branch_keeper need here?
-    p >= 1 ? m*k : p > 0 ? Int(ceil(-expm1(log1p(-p) * n)*m*k)) : 0 
-end
+end 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -27,8 +27,8 @@ const DenseInputVecOrMat = Union{AdjOrTransDenseMatrix, StridedVector}
 end
 
 
-for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
-    @eval @i function imul!(C::StridedVecOrMat, xA::$T{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
+
+@i function imul!(C::StridedVecOrMat, xA::Adjoint{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
         @safe size(xA.parent, 2) == size(C, 1) || throw(DimensionMismatch())
         @safe size(xA.parent, 1) == size(B, 1) || throw(DimensionMismatch())
         @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
@@ -38,16 +38,16 @@ for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
         @invcheckoff for k in 1:size(C, 2)
             @inbounds for col in 1:size(xA.parent, 2)
                     for j in nzrange(xA.parent, col)
-                    anc2 ← zero(eltype(xA))
-                    anc2 += $t(xA.parent.nzval[j])
-                    C[col,k] += anc2*B[xA.parent.rowval[j], k]
-                    anc2 -= $t(xA.parent.nzval[j])
-                    anc2 → zero(eltype(xA))
+                    anc1 ← zero(eltype(xA))
+                    anc1 += (xA.parent.nzval[j])'
+                    C[col,k] += anc1*B[xA.parent.rowval[j], k]
+                    anc1 -= (xA.parent.nzval[j])'
+                    anc1 → zero(eltype(xA))
                 end
             end
         end
     end
-end
+
 
 @i function imul!(C::StridedVecOrMat, X::DenseMatrixUnion, A::AbstractSparseMatrix, α::Number, β::Number)
     @safe size(X, 2) == size(A, 1) || throw(DimensionMismatch())
@@ -97,3 +97,115 @@ end
         end
     end
 end
+
+@i function imul!(C::StridedVecOrMat, X::DenseMatrixUnion, xA::Adjoint{<:Any,<:AbstractSparseMatrix}, α::Number, β::Number)
+    @safe size(X, 2) == size(xA.parent, 2) || throw(DimensionMismatch())
+    @safe size(X, 1) == size(C, 1) || throw(DimensionMismatch())
+    @safe size(xA.parent, 1) == size(C, 2) || throw(DimensionMismatch())
+    if (β != 1, ~)
+        @safe error("only β = 1 is supported, got β = $(β).")
+    end
+    @invcheckoff for col in 1:size(xA.parent, 2)
+        @inbounds for k in nzrange(xA.parent, col)
+                        anc1 ← zero(eltype(xA.parent))
+                        anc1 += (xA.parent.nzval[k])'
+            @simd for multivec_row in 1:size(X,1)
+                C[multivec_row, xA.parent.rowval[k]] += X[multivec_row, col]*anc1*α
+            end
+            anc1 -= (xA.parent.nzval[k])'
+            anc1 → zero(eltype(xA.parent))
+        end
+    end
+end
+
+@i function idot(r::T, A::SparseMatrixCSC{T},B::SparseMatrixCSC{T}) where {T}
+    @routine @invcheckoff begin
+        (m, n) ← size(A)
+        branch_keeper ← zeros(Bool, 2*m)
+    end
+    @safe size(B) == (m,n) || throw(DimensionMismatch("matrices must have the same dimensions"))
+    @invcheckoff @inbounds for j = 1:n
+        @routine begin
+            ia1 ← A.colptr[j]
+            ib1 ← B.colptr[j]
+            ia2 ← A.colptr[j+1]
+            ib2 ← B.colptr[j+1]
+            ia ← ia1
+            ib ← ib1
+        end
+        @inbounds for i=1:ia2-ia1+ib2-ib1-1
+            ra ← A.rowval[ia]
+            rb ← B.rowval[ib]
+            if (ra == rb, ~)
+                r += A.nzval[ia]' * B.nzval[ib]
+            end
+            ## b move -> true, a move -> false
+            branch_keeper[i] ⊻= @const ia == ia2-1 || (ib != ib2-1 && ra > rb)
+            ra → A.rowval[ia]
+            rb → B.rowval[ib]
+            if (branch_keeper[i], ~)
+                INC(ib)
+            else
+                INC(ia)
+            end
+        end
+        ~@inbounds for i=1:ia2-ia1+ib2-ib1-1
+            ## b move -> true, a move -> false
+            branch_keeper[i] ⊻= @const ia == ia2-1 || (ib != ib2-1 && A.rowval[ia] > B.rowval[ib])
+            if (branch_keeper[i], ~)
+                INC(ib)
+            else
+                INC(ia)
+            end
+        end
+        ~@routine
+    end
+    ~@routine
+end
+
+# function dot(A::AbstractSparseMatrixCSC{T1,S1},B::AbstractSparseMatrixCSC{T2,S2}) where {T1,T2,S1,S2}
+#     # A and B should be the same size
+#     m, n = size(A)
+#     size(B) == (m,n) || throw(DimensionMismatch("matrices must have the same dimensions"))
+#     r = dot(zero(T1), zero(T2))
+#     # sparse vector dot iterating by columns in A
+#     @inbounds for j = 1:n
+#         # get nonzero element in A[:,j]/B[:,j] with row idx ra/rb 
+#         ia = getcolptr(A)[j]; ia_nxt = getcolptr(A)[j+1]
+#         ib = getcolptr(B)[j]; ib_nxt = getcolptr(B)[j+1]
+#         if ia < ia_nxt && ib < ib_nxt
+#             ra = rowvals(A)[ia]; rb = rowvals(B)[ib]
+#             # iteration in A[:,j]/B[:,j]
+#             while true
+#                 if ra < rb # match false samller ra
+#                     ia += oneunit(S1)
+#                     ia < ia_nxt || break
+#                     ra = rowvals(A)[ia] # update ra bigger
+#                 elseif ra > rb # match false sammler rb
+#                     ib += oneunit(S2)
+#                     ib < ib_nxt || break
+#                     rb = rowvals(B)[ib] # update rb bigger
+#                 else # ra == rb
+#                     r += dot(nonzeros(A)[ia], nonzeros(B)[ib]) # equals to A.nzval[ia]' * B.nzval[ib]
+#                     ia += oneunit(S1); ib += oneunit(S2)
+#                     ia < ia_nxt && ib < ib_nxt || break
+#                     ra = rowvals(A)[ia]; rb = rowvals(B)[ib] # update next ra and rb
+#                 end
+#             end
+#         end
+#     end
+#     return r
+# end
+
+# strange result but I couldn't correct
+@i function idot!(r, x::AbstractVector, A::AbstractSparseMatrix, y::AbstractVector) 
+    @safe length(x) == size(A, 1) || throw(DimensionMismatch())
+    @safe length(y) == size(A, 2) || throw(DimensionMismatch())
+
+    @inbounds for col in size(A, 2)
+        for k in nzrange(A, col)
+            r += (x[A.rowval[k]])' * A.nzval[k] * y[col]
+        end
+    end
+end 
+

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,0 +1,81 @@
+# declare struct 
+const DenseMatrixUnion = Union{StridedMatrix, LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular, BitMatrix}
+const AdjOrTransDenseMatrix = Union{DenseMatrixUnion,Adjoint{<:Any,<:DenseMatrixUnion},Transpose{<:Any,<:DenseMatrixUnion}}
+const DenseInputVector = Union{StridedVector, BitVector}
+const DenseInputVecOrMat = Union{AdjOrTransDenseMatrix, StridedVector}
+
+
+@i function imul!(C::StridedVecOrMat, A::AbstractSparseMatrix, B::DenseInputVecOrMat, α::Number, β::Number) 
+    @safe size(A, 2) == size(B, 1) || throw(DimensionMismatch())
+    @safe size(A, 1) == size(C, 1) || throw(DimensionMismatch())
+    @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+    if (β != 1, ~)
+        @safe error("only β = 1 is supported, got β = $(β).")
+    end
+    # Here, we close the reversibility check inside the loop to increase performance
+    @invcheckoff for k = 1:size(C, 2)
+        @inbounds for col = 1:size(A, 2)
+            αxj ← zero(eltype(B))
+            αxj += B[col,k] * α
+            for j = nzrange(A, col)
+                C[A.rowval[j], k] += A.nzval[j]*αxj
+            end
+            αxj -= B[col,k] * α
+            αxj → zero(eltype(B))
+        end
+    end
+end
+
+
+for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
+    @eval @i function imul!(C::StridedVecOrMat, xA::$T{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
+        @safe size(xA.parent, 2) == size(C, 1) || throw(DimensionMismatch())
+        @safe size(xA.parent, 1) == size(B, 1) || throw(DimensionMismatch())
+        @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+        if (β != 1, ~)
+            @safe error("only β = 1 is supported, got β = $(β).")
+        end
+        @invcheckoff for k in 1:size(C, 2)
+            @inbounds for col in 1:size(xA.parent, 2)
+                    for j in nzrange(xA.parent, col)
+                    anc2 ← zero(eltype(xA))
+                    anc2 += $t(xA.parent.nzval[j])
+                    C[col,k] += anc2*B[xA.parent.rowval[j], k]
+                    anc2 -= $t(xA.parent.nzval[j])
+                    anc2 → zero(eltype(xA))
+                end
+            end
+        end
+    end
+end
+
+# this is an implementation with tmp variables
+# worser performance than no alias version above in benchmark results
+
+# for (T, t) in ((Adjoint, adjoint), (Transpose, transpose))
+#     @eval @i function imult!(C::StridedVecOrMat, xA::$T{<:Any,<:AbstractSparseMatrix}, B::DenseInputVecOrMat, α::Number, β::Number)
+#         @safe size(xA.parent, 2) == size(C, 1) || throw(DimensionMismatch())
+#         @safe size(xA.parent, 1) == size(B, 1) || throw(DimensionMismatch())
+#         @safe size(B, 2) == size(C, 2) || throw(DimensionMismatch())
+#         if (β != 1, ~)
+#             @safe error("only β = 1 is supported, got β = $(β).")
+#         end
+#         @invcheckoff for k in 1:size(C, 2)
+#             @inbounds for col in 1:size(xA.parent, 2)
+#                 @routine begin
+#                 tmp ← zero(eltype(C))
+#                 for j in nzrange(xA.parent, col)
+#                     @routine begin
+#                     anc2 ← zero(eltype(xA))
+#                     anc2 += $t(xA.parent.nzval[j])
+#                     end
+#                     tmp += anc2*B[xA.parent.rowval[j],k]
+#                     ~@routine
+#                 end
+#                 C[col,k] += tmp * α
+#                 end
+#                 ~@routine
+#             end
+#         end
+#     end
+# end

--- a/src/sparsegrad.jl
+++ b/src/sparsegrad.jl
@@ -1,13 +1,7 @@
 ###calculate jacobian by NiLang###
-"""
-    helper function params and fitparams
-        function params wraps parameters in track of gradient when given array/matrix.
-            params(v::DenseArray)
-            params(A::SparseMatrixCSC)
-        function fitparams fits the original datastructure with parameters in track of gradient.
-            fitparams(v::DenseArray)
-            fitparams(A::SparseMatrixCSC)
-"""
+
+# function params wraps parameters in track of gradient when given array/matrix.
+# function fitparams fits the original datastructure with parameters in track of gradient.
 params(v::DenseArray{<:Real}) = v
 fitparams(v::DenseArray{<:Real}, p) = p
 params(v::DenseArray{<:Complex{T}}) where T = collect(reinterpret(T, v))
@@ -16,8 +10,9 @@ params(A::SparseMatrixCSC) = params(A.nzval)
 fitparams(A::SparseMatrixCSC, p) = SparseMatrixCSC(A.m, A.n, A.colptr, A.rowval, fitparams(A.nzval, p))
 
 """
-    mvloss(l, j, y::AbstractArray{<:Real}, A, x) -> scalar l 
-mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Real Type)   
+    mmloss(l, j, y::AbstractArray{<:Real}, A, x) -> scalar l 
+
+mmloss defines loss on sparse-matrix & dense vector/matrix multiplication(Real Type)   
 """
 @i function mmloss(l, j, y::AbstractArray{<:Real}, A, x)
     imul!(y, A, x, 1.0, 1.0)
@@ -25,8 +20,9 @@ mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Real T
 end
 
 """
-    mvloss(l, j, y::AbstractArray{<:Complex}, A, x) -> scalar l 
-mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Complex Type)   
+    mmloss(l, j, y::AbstractArray{<:Complex}, A, x) -> scalar l 
+
+mmloss defines loss on sparse-matrix & dense vector/matrix multiplication(Complex Type)   
 """
 @i function mmloss(l, j, y::AbstractArray{<:Complex}, A, x)
     imul!(y, A, x, 1.0, 1.0)
@@ -38,8 +34,9 @@ mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Comple
 end
 
 """
-    nilang_mv_jacobian(A, x::AbstractArray) -> AbstractArray J
-nilang_mv_jacobian calculates the jacobian with respect to parameter A and x based on mvloss in NiLang
+    nilang_mm_jacobian(A, x::AbstractArray) -> AbstractArray J
+
+nilang_mm_jacobian calculates the jacobian with respect to parameter A and x based on mvloss in NiLang
 """
 function nilang_mm_jacobian(A, x::AbstractArray)
     px, pA = params(x), params(A)

--- a/src/sparsegrad.jl
+++ b/src/sparsegrad.jl
@@ -1,0 +1,69 @@
+###calculate jacobian by NiLang###
+"""
+    helper function params and fitparams
+        function params wraps parameters in track of gradient when given array/matrix.
+            params(v::DenseArray)
+            params(A::SparseMatrixCSC)
+        function fitparams fits the original datastructure with parameters in track of gradient.
+            fitparams(v::DenseArray)
+            fitparams(A::SparseMatrixCSC)
+"""
+params(v::DenseArray{<:Real}) = v
+fitparams(v::DenseArray{<:Real}, p) = p
+params(v::DenseArray{<:Complex{T}}) where T = collect(reinterpret(T, v))
+fitparams(v::DenseArray{<:T}, p::DenseArray{T2}) where {T<:Complex,T2} = collect(reinterpret(Complex{T2}, p))
+params(A::SparseMatrixCSC) = params(A.nzval)
+fitparams(A::SparseMatrixCSC, p) = SparseMatrixCSC(A.m, A.n, A.colptr, A.rowval, fitparams(A.nzval, p))
+
+"""
+    mvloss(l, j, y::AbstractArray{<:Real}, A, x) -> scalar l 
+mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Real Type)   
+"""
+@i function mvloss(l, j, y::AbstractArray{<:Real}, A, x)
+    imul!(y, A, x, 1.0, 1.0)
+    l += y[j]
+end
+
+"""
+    mvloss(l, j, y::AbstractArray{<:Complex}, A, x) -> scalar l 
+mvloss defines loss on sparse-matrix & dense vector/matrix multiplication(Complex Type)   
+"""
+@i function mvloss(l, j, y::AbstractArray{<:Complex}, A, x)
+    imul!(y, A, x, 1.0, 1.0)
+    if j%2 == 1
+        l += y[div(j-1,2)+1].re
+    else
+        l += y[div(j-1,2)+1].im
+    end
+end
+
+"""
+    nilang_mv_jacobian(A, x::AbstractArray) -> AbstractArray J
+nilang_mv_jacobian calculates the jacobian with respect to parameter A and x based on mvloss in NiLang
+"""
+function nilang_mv_jacobian(A, x::AbstractArray)
+    px, pA = params(x), params(A)
+    J = zeros(eltype(px), length(px), length(px) + length(pA))
+    for j=1:length(px)
+        _, _, _, _, gA, gx = NiLang.AD.Grad(mvloss)(Val(1), 0.0, j, zero(x), A, x)
+        J[j,:] = vcat(grad(params(gA)), grad(params(gx)))
+    end
+    return J
+end
+
+"""
+    forwarddiff_mv_jacobian(A, x) -> AbstractArray J 
+forwarddiff_mv_jacobian calculates the jacobian with respect to parameter A and x based on multiplication in ForwardDiff
+"""
+function forwarddiff_mv_jacobian(A, x)
+    pA = params(A)
+    px = params(x)
+    pAx = vcat(pA, px)
+    ForwardDiff.jacobian(pAx) do pAx
+        pA = pAx[1:length(pA)]
+        px = pAx[length(pA)+1:end]
+        A2 = fitparams(A, pA)
+        x2 = fitparams(x, px)
+        y = params(A2 * x2)
+    end
+end

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,0 +1,29 @@
+using SparseArrays: sprand
+import SparseArrays
+using BenchmarkTools
+using BenchmarkPlots, StatsPlots
+using NiSparseArrays:idotxA, idotAx
+
+m, n = 1000, 500;
+x = sprand(m, 0.2)
+A = sprand(m, n, 0.2)
+y = sprand(n, 0.3)
+
+println("Benchmark on SparseArrays dot function: ")
+sdf = @benchmarkable SparseArrays.dot($x, $A, $y)
+run(sdf)
+
+r = zero(eltype(A))
+println("Benchmark on NiSparseArrays idotxA function: ")
+xAf = @benchmarkable idotxA($copy(r), $x, $A, $y)
+run(xAf)
+
+r = zero(eltype(A))
+println("Benchmark on NiSparseArrays idotAx function: ")
+Axf = @benchmarkable idotAx($copy(r), $x, $A, $y)
+run(Axf)
+
+
+
+
+

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,4 +1,4 @@
-using NiSparseArrays:imul!, forwarddiff_mv_jacobian, nilang_mv_jacobian
+using NiSparseArrays:imul!, nilang_mm_jacobian
 const approx_rtol = 100*eps()
 
 # real value case
@@ -56,13 +56,12 @@ end
     end
 end
 
-
 @testset "jacobian" begin
     for T in [Float64, ComplexF64]
         A = sprand(T, 10, 10, 0.2)
         x = randn(T, 10)
-        JF = forwarddiff_mv_jacobian(A, x)
-        JN = nilang_mv_jacobian(A, x)
+        JF = forwarddiff_mm_jacobian(A, x)
+        JN = nilang_mm_jacobian(A, x)
         @test isapprox(JF, JN)
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,110 +1,121 @@
-using NiSparseArrays:imul!, nilang_mm_jacobian, idot!
+using NiSparseArrays:imul!, nilang_mm_jacobian, idot!, i_spmatmul
 const approx_rtol = 100*eps()
 
-@testset "matrix multiplication" begin
+# @testset "matrix multiplication" begin
+#     for i = 1:5
+#         A = sprand(10, 5, 0.5)
+#         b = rand(5)
+#         outv = A*b
+#         c = zero(outv)
+#         ioutv = imul!(copy(c), A, b, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+#         @test ≈(ioutv, outv, rtol=approx_rtol)
+
+#         B = rand(5, 3)
+#         outm = A*B
+#         C = zero(outm)
+#         ioutm = imul!(copy(C), A, B, 1, 1)[1]
+#         @test ≈(ioutm, outm, rtol=approx_rtol)
+#     end
+# end
+
+# @testset "complex matrix multiplication" begin
+#     for i = 1:5
+#         A = sprand(ComplexF64, 10, 5, 0.2)
+#         b = rand(ComplexF64, 5)
+#         outv = A*b
+#         c = zero(outv)
+#         ioutv = imul!(copy(c), A, b, 1, 1)[1]
+#         @test ≈(ioutv, outv, rtol=approx_rtol)
+
+#         B = rand(ComplexF64, 5, 3)
+#         outm = A*B
+#         C = zero(outm)
+#         ioutm = imul!(copy(C), A, B, 1, 1)[1]
+#         @test ≈(ioutm, outm, rtol=approx_rtol)
+#     end
+# end
+
+# @testset "adjoint matrix multiplication" begin
+#         for i = 1:5
+#             A = sprand(ComplexF64, 5, 5, 0.2)
+#             b = rand(ComplexF64, 5)
+#             outv = A'*b
+#             c= zero(outv)
+#             ioutv = imul!(copy(c), A', b, 1, 1)[1]
+#             @test ≈(ioutv, outv, rtol=approx_rtol)
+
+#             B = rand(ComplexF64, 5, 3)
+#             outm = A'*B
+#             C = zero(outm)
+#             ioutm = imul!(copy(C), A', B, 1, 1)[1]
+#             @test ≈(ioutm, outm, rtol=approx_rtol)
+#         end
+# end
+
+
+
+# @testset "jacobian" begin
+#     for T in [Float64, ComplexF64]
+#         A = sprand(T, 10, 10, 0.2)
+#         x = randn(T, 10)
+#         JF = forwarddiff_mm_jacobian(A, x)
+#         JN = nilang_mm_jacobian(A, x)
+#         @test isapprox(JF, JN)
+#     end
+# end
+
+# @testset "dense matrix-sparse matrix multiplication" begin
+#     for i = 1:5
+#         B = rand(10, 10)
+#         A = sprand(10, 5, 0.5)
+#         outm = B*A
+#         C = zero(outm)
+#         ioutm = imul!(copy(C), B, A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+#         @test ≈(ioutm, outm, rtol=approx_rtol)
+#     end
+# end
+
+# @testset "adjoint dense matrix-sparse matrix multiplication" begin
+#     for i = 1:5
+#         B = rand(10, 5)
+#         A = sprand(10, 5, 0.5)
+#         outm = B'*A
+#         C = zero(outm)
+#         ioutm = imul!(copy(C), B', A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+#         @test ≈(ioutm, outm, rtol=approx_rtol)
+#     end
+# end
+
+# @testset "dense matrix - adjoint sparse matrix multiplication" begin
+#     for i = 1:5
+#         B = rand(10, 10)
+#         A = sprand(5, 10, 0.5)
+#         outm = B*A'
+#         C = zero(outm)
+#         ioutm = imul!(copy(C), B, A', 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+#         @test ≈(ioutm, outm, rtol=approx_rtol)
+#     end
+# end
+
+# @testset "dense vector - sparse matrix dot" begin
+#     for i = 1:5
+#         x = rand(Float64, 10)
+#         A = sprand(10, 5, 0.2)
+#         y = rand(Float64, 5)
+#         outd = dot(x, A, y)
+#         r = zero(Float64)
+#         ioutd = idot!(copy(r), x, A, y)[1]
+#         @test ≈(ioutd, outd, rtol=approx_rtol)
+#     end
+# end
+
+@testset "simple spatmul implementaation" begin
     for i = 1:5
-        A = sprand(10, 5, 0.5)
-        b = rand(5)
-        outv = A*b
-        c = zero(outv)
-        ioutv = imul!(copy(c), A, b, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-        @test ≈(ioutv, outv, rtol=approx_rtol)
+        A = sprand(10,10,0.2);
+        B = sprand(10,10,0.3);
+        C = spmatmul(A, B);
+        iC = i_spmatmul(A, B);
+        @test ≈(C, iC, rtol=approx_rtol)
 
-        B = rand(5, 3)
-        outm = A*B
-        C = zero(outm)
-        ioutm = imul!(copy(C), A, B, 1, 1)[1]
-        @test ≈(ioutm, outm, rtol=approx_rtol)
-    end
-end
-
-@testset "complex matrix multiplication" begin
-    for i = 1:5
-        A = sprand(ComplexF64, 10, 5, 0.2)
-        b = rand(ComplexF64, 5)
-        outv = A*b
-        c = zero(outv)
-        ioutv = imul!(copy(c), A, b, 1, 1)[1]
-        @test ≈(ioutv, outv, rtol=approx_rtol)
-
-        B = rand(ComplexF64, 5, 3)
-        outm = A*B
-        C = zero(outm)
-        ioutm = imul!(copy(C), A, B, 1, 1)[1]
-        @test ≈(ioutm, outm, rtol=approx_rtol)
-    end
-end
-
-@testset "adjoint matrix multiplication" begin
-        for i = 1:5
-            A = sprand(ComplexF64, 5, 5, 0.2)
-            b = rand(ComplexF64, 5)
-            outv = A'*b
-            c= zero(outv)
-            ioutv = imul!(copy(c), A', b, 1, 1)[1]
-            @test ≈(ioutv, outv, rtol=approx_rtol)
-
-            B = rand(ComplexF64, 5, 3)
-            outm = A'*B
-            C = zero(outm)
-            ioutm = imul!(copy(C), A', B, 1, 1)[1]
-            @test ≈(ioutm, outm, rtol=approx_rtol)
-        end
-end
-
-
-
-@testset "jacobian" begin
-    for T in [Float64, ComplexF64]
-        A = sprand(T, 10, 10, 0.2)
-        x = randn(T, 10)
-        JF = forwarddiff_mm_jacobian(A, x)
-        JN = nilang_mm_jacobian(A, x)
-        @test isapprox(JF, JN)
-    end
-end
-
-@testset "dense matrix-sparse matrix multiplication" begin
-    for i = 1:5
-        B = rand(10, 10)
-        A = sprand(10, 5, 0.5)
-        outm = B*A
-        C = zero(outm)
-        ioutm = imul!(copy(C), B, A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-        @test ≈(ioutm, outm, rtol=approx_rtol)
-    end
-end
-
-@testset "adjoint dense matrix-sparse matrix multiplication" begin
-    for i = 1:5
-        B = rand(10, 5)
-        A = sprand(10, 5, 0.5)
-        outm = B'*A
-        C = zero(outm)
-        ioutm = imul!(copy(C), B', A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-        @test ≈(ioutm, outm, rtol=approx_rtol)
-    end
-end
-
-@testset "dense matrix - adjoint sparse matrix multiplication" begin
-    for i = 1:5
-        B = rand(10, 10)
-        A = sprand(5, 10, 0.5)
-        outm = B*A'
-        C = zero(outm)
-        ioutm = imul!(copy(C), B, A', 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-        @test ≈(ioutm, outm, rtol=approx_rtol)
-    end
-end
-
-@testset "dense vector - sparse matrix dot" begin
-    for i = 1:5
-        x = rand(Float64, 10)
-        A = sprand(10, 5, 0.2)
-        y = rand(Float64, 5)
-        outd = dot(x, A, y)
-        r = zero(Float64)
-        ioutd = idot!(copy(r), x, A, y)[1]
-        @test ≈(ioutd, outd, rtol=approx_rtol)
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,7 +1,6 @@
 using NiSparseArrays:imul!, nilang_mm_jacobian
 const approx_rtol = 100*eps()
 
-# real value case
 @testset "matrix multiplication" begin
     for i = 1:5
         A = sprand(10, 5, 0.5)
@@ -19,7 +18,6 @@ const approx_rtol = 100*eps()
     end
 end
 
-# complex value case
 @testset "complex matrix multiplication" begin
     for i = 1:5
         A = sprand(ComplexF64, 10, 5, 0.2)
@@ -56,6 +54,8 @@ end
     end
 end
 
+
+
 @testset "jacobian" begin
     for T in [Float64, ComplexF64]
         A = sprand(T, 10, 10, 0.2)
@@ -63,5 +63,27 @@ end
         JF = forwarddiff_mm_jacobian(A, x)
         JN = nilang_mm_jacobian(A, x)
         @test isapprox(JF, JN)
+    end
+end
+
+@testset "dense matrix-sparse matrix multiplication" begin
+    for i = 1:5
+        B = rand(10, 10)
+        A = sprand(10, 5, 0.5)
+        outm = B*A
+        C = zero(outm)
+        ioutm = imul!(copy(C), B, A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+        @test ≈(ioutm, outm, rtol=approx_rtol)
+    end
+end
+
+@testset "adjoint dense matrix-sparse matrix multiplication" begin
+    for i = 1:5
+        B = rand(10, 5)
+        A = sprand(10, 5, 0.5)
+        outm = B'*A
+        C = zero(outm)
+        ioutm = imul!(copy(C), B', A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+        @test ≈(ioutm, outm, rtol=approx_rtol)
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,121 +1,54 @@
-using NiSparseArrays:imul!, nilang_mm_jacobian, idot!, i_spmatmul
+using NiSparseArrays:idotxA, idotAx
 const approx_rtol = 100*eps()
 
-# @testset "matrix multiplication" begin
-#     for i = 1:5
-#         A = sprand(10, 5, 0.5)
-#         b = rand(5)
-#         outv = A*b
-#         c = zero(outv)
-#         ioutv = imul!(copy(c), A, b, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-#         @test ≈(ioutv, outv, rtol=approx_rtol)
-
-#         B = rand(5, 3)
-#         outm = A*B
-#         C = zero(outm)
-#         ioutm = imul!(copy(C), A, B, 1, 1)[1]
-#         @test ≈(ioutm, outm, rtol=approx_rtol)
-#     end
-# end
-
-# @testset "complex matrix multiplication" begin
-#     for i = 1:5
-#         A = sprand(ComplexF64, 10, 5, 0.2)
-#         b = rand(ComplexF64, 5)
-#         outv = A*b
-#         c = zero(outv)
-#         ioutv = imul!(copy(c), A, b, 1, 1)[1]
-#         @test ≈(ioutv, outv, rtol=approx_rtol)
-
-#         B = rand(ComplexF64, 5, 3)
-#         outm = A*B
-#         C = zero(outm)
-#         ioutm = imul!(copy(C), A, B, 1, 1)[1]
-#         @test ≈(ioutm, outm, rtol=approx_rtol)
-#     end
-# end
-
-# @testset "adjoint matrix multiplication" begin
-#         for i = 1:5
-#             A = sprand(ComplexF64, 5, 5, 0.2)
-#             b = rand(ComplexF64, 5)
-#             outv = A'*b
-#             c= zero(outv)
-#             ioutv = imul!(copy(c), A', b, 1, 1)[1]
-#             @test ≈(ioutv, outv, rtol=approx_rtol)
-
-#             B = rand(ComplexF64, 5, 3)
-#             outm = A'*B
-#             C = zero(outm)
-#             ioutm = imul!(copy(C), A', B, 1, 1)[1]
-#             @test ≈(ioutm, outm, rtol=approx_rtol)
-#         end
-# end
-
-
-
-# @testset "jacobian" begin
-#     for T in [Float64, ComplexF64]
-#         A = sprand(T, 10, 10, 0.2)
-#         x = randn(T, 10)
-#         JF = forwarddiff_mm_jacobian(A, x)
-#         JN = nilang_mm_jacobian(A, x)
-#         @test isapprox(JF, JN)
-#     end
-# end
-
-# @testset "dense matrix-sparse matrix multiplication" begin
-#     for i = 1:5
-#         B = rand(10, 10)
-#         A = sprand(10, 5, 0.5)
-#         outm = B*A
-#         C = zero(outm)
-#         ioutm = imul!(copy(C), B, A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-#         @test ≈(ioutm, outm, rtol=approx_rtol)
-#     end
-# end
-
-# @testset "adjoint dense matrix-sparse matrix multiplication" begin
-#     for i = 1:5
-#         B = rand(10, 5)
-#         A = sprand(10, 5, 0.5)
-#         outm = B'*A
-#         C = zero(outm)
-#         ioutm = imul!(copy(C), B', A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-#         @test ≈(ioutm, outm, rtol=approx_rtol)
-#     end
-# end
-
-# @testset "dense matrix - adjoint sparse matrix multiplication" begin
-#     for i = 1:5
-#         B = rand(10, 10)
-#         A = sprand(5, 10, 0.5)
-#         outm = B*A'
-#         C = zero(outm)
-#         ioutm = imul!(copy(C), B, A', 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
-#         @test ≈(ioutm, outm, rtol=approx_rtol)
-#     end
-# end
-
-# @testset "dense vector - sparse matrix dot" begin
-#     for i = 1:5
-#         x = rand(Float64, 10)
-#         A = sprand(10, 5, 0.2)
-#         y = rand(Float64, 5)
-#         outd = dot(x, A, y)
-#         r = zero(Float64)
-#         ioutd = idot!(copy(r), x, A, y)[1]
-#         @test ≈(ioutd, outd, rtol=approx_rtol)
-#     end
-# end
-
-@testset "simple spatmul implementaation" begin
-    for i = 1:5
-        A = sprand(10,10,0.2);
-        B = sprand(10,10,0.3);
-        C = spmatmul(A, B);
-        iC = i_spmatmul(A, B);
-        @test ≈(C, iC, rtol=approx_rtol)
-
+@testset "sparse dot xA" begin
+    for T in (Float64, ComplexF64)    
+        for i = 1:5
+            x = sprand(T, 10, 0.2)
+            A = sprand(T, 10, 5, 0.2)
+            y = sprand(T, 5, 0.3)
+            outd = dot(x, A, y)
+            r = zero(T)
+            ioutd = idotxA(copy(r), x, A, y)[1]
+            @test ≈(ioutd, outd, rtol=approx_rtol)
+        end
     end
 end
+
+@testset "sparse dot Ax" begin
+    for T in (Float64, ComplexF64)    
+        for i = 1:5
+            x = sprand(T, 10, 0.2)
+            A = sprand(T, 10, 5, 0.2)
+            y = sprand(T, 5, 0.3)
+            outd = dot(x, A, y)
+            r = zero(T)
+            ioutd = idotAx(copy(r), x, A, y)[1]
+            @test ≈(ioutd, outd, rtol=approx_rtol)
+        end
+    end
+end
+
+# m, n = 1000, 500;
+# x = sprand(m, 0.2)
+# A = sprand(m, n, 0.2)
+# y = sprand(n, 0.3)
+# r = zero(eltype(A))
+
+# @testset "SparseArrays dot benchmark" begin
+#     sdb = @benchmarkable SparseArrays.dot($x, $A, $y)
+#     run(sdb)
+#     plot(sdb)
+# end
+
+# @testset "idotxA benchmark" begin    
+#     xAb = @benchmarkable idotxA($copy(r), $x, $A, $y)
+#     run(xAb)
+#     plot(xAb)
+# end
+
+# @testset "idotAx benchmark" begin
+#     Axb = @benchmarkable idotAx($copy(r), $x, $A, $y)
+#     run(Axb)
+#     plot(Axb)
+# end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,15 +1,6 @@
-using NiSparseArrays:imul!
-using SparseArrays, Random, Test
-Random.seed!(1234)
-using NiLang, ForwardDiff
-using NiLang.AD
+using NiSparseArrays:imul!, forwarddiff_mv_jacobian, nilang_mv_jacobian
+const approx_rtol = 100*eps()
 
-# Is declaring approx_rtol here safe? But I don't want to declare approx_rtol in each testset...
-approx_rtol = 100*eps()
-# Would it be reasonable to test accuracy like this? Is there any better readable code?
-# ≈(ioutv, outv, rtol=approx_rtol) 
-# keep the same style with SparseArrays 
-# https://github.com/JuliaLang/julia/blob/b773bebcdb1eccaf3efee0bfe564ad552c0bcea7/stdlib/SparseArrays/test/sparse.jl#L254 
 # real value case
 @testset "matrix multiplication" begin
     for i = 1:5
@@ -65,56 +56,13 @@ end
     end
 end
 
-###### Test jacobian matrix ######
-params(A::SparseMatrixCSC) = params(A.nzval)
-fitparams(A::SparseMatrixCSC, p) = SparseMatrixCSC(A.m, A.n, A.colptr, A.rowval, fitparams(A.nzval, p))
-params(v::DenseArray{<:Real}) = v
-fitparams(v::DenseArray{<:Real}, p) = p
-params(v::DenseArray{<:Complex{T}}) where T = collect(reinterpret(T, v))
-fitparams(v::DenseArray{<:T}, p::DenseArray{T2}) where {T<:Complex,T2} = collect(reinterpret(Complex{T2}, p))
-
-@i function loss(l, j, y::AbstractArray{<:Real}, A, x)
-    imul!(y, A, x, 1.0, 1.0)
-    l += y[j]
-end
-@i function loss(l, j, y::AbstractArray{<:Complex}, A, x)
-    imul!(y, A, x, 1.0, 1.0)
-    if j%2 == 1
-        l += y[div(j-1,2)+1].re
-    else
-        l += y[div(j-1,2)+1].im
-    end
-end
-
-function nilang_mul_jacobian(A, x::AbstractArray)
-    px, pA = params(x), params(A)
-    J = zeros(T, length(px), length(px) + length(pA))
-    for j=1:length(px)
-        _, _, _, _, gA, gx = NiLang.AD.Grad(loss)(Val(1), 0.0, j, zero(x), A, x)
-        J[j,:] = vcat(grad(params(gA)), grad(params(gx)))
-    end
-    return J
-end
-
-function forwarddiff_mul_jacobian(A, x)
-    pA = params(A)
-    px = params(x)
-    pAx = vcat(pA, px)
-    ForwardDiff.jacobian(pAx) do pAx
-        pA = pAx[1:length(pA)]
-        px = pAx[length(pA)+1:end]
-        A2 = fitparams(A, pA)
-        x2 = fitparams(x, px)
-        y = params(A2 * x2)
-    end
-end
 
 @testset "jacobian" begin
     for T in [Float64, ComplexF64]
         A = sprand(T, 10, 10, 0.2)
         x = randn(T, 10)
-        JF = forwarddiff_mul_jacobian(A, x)
-        JN = nilang_mul_jacobian(A, x)
+        JF = forwarddiff_mv_jacobian(A, x)
+        JN = nilang_mv_jacobian(A, x)
         @test isapprox(JF, JN)
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,0 +1,64 @@
+using NiSparseArrays:imul!
+using SparseArrays, Random, Test
+Random.seed!(1234)
+
+# Is declaring approx_rtol here safe? But I don't want to declare approx_rtol in each testset...
+approx_rtol = 100*eps()
+# Would it be reasonable to test accuracy like this? Is there any better readable code?
+# ≈(ioutv, outv, rtol=approx_rtol) 
+# keep the same style with SparseArrays 
+# https://github.com/JuliaLang/julia/blob/b773bebcdb1eccaf3efee0bfe564ad552c0bcea7/stdlib/SparseArrays/test/sparse.jl#L254 
+# real value case
+@testset "matrix multiplication" begin
+    for i = 1:5
+        A = sprand(10, 5, 0.5)
+        b = rand(5)
+        outv = A*b
+        c = zero(outv)
+        ioutv = imul!(copy(c), A, b, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+        @test ≈(ioutv, outv, rtol=approx_rtol)
+
+        B = rand(5, 3)
+        outm = A*B
+        C = zero(outm)
+        ioutm = imul!(copy(C), A, B, 1, 1)[1]
+        @test ≈(ioutm, outm, rtol=approx_rtol)
+    end
+end
+
+# complex value case
+@testset "complex matrix multiplication" begin
+    for i = 1:5
+        A = sprand(ComplexF64, 10, 5, 0.2)
+        b = rand(ComplexF64, 5)
+        outv = A*b
+        c = zero(outv)
+        ioutv = imul!(copy(c), A, b, 1, 1)[1]
+        @test ≈(ioutv, outv, rtol=approx_rtol)
+
+        B = rand(ComplexF64, 5, 3)
+        outm = A*B
+        C = zero(outm)
+        ioutm = imul!(copy(C), A, B, 1, 1)[1]
+        @test ≈(ioutm, outm, rtol=approx_rtol)
+    end
+end
+
+@testset "adjoint/transpose matrix multiplication" begin
+    for t in (adjoint, transpose)
+        @eval for i = 1:5
+            A = sprand(ComplexF64, 5, 5, 0.2)
+            b = rand(ComplexF64, 5)
+            outv = $t(A)*b
+            c= zero(outv)
+            ioutv = imul!(copy(c), $t(A), b, 1, 1)[1]
+            @test ≈(ioutv, outv, rtol=approx_rtol)
+
+            B = rand(ComplexF64, 5, 3)
+            outm = $t(A)*B
+            C = zero(outm)
+            ioutm = imul!(copy(C), $t(A), B, 1, 1)[1]
+            @test ≈(ioutm, outm, rtol=approx_rtol)
+        end
+    end
+end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,4 +1,4 @@
-using NiSparseArrays:imul!, nilang_mm_jacobian
+using NiSparseArrays:imul!, nilang_mm_jacobian, idot!
 const approx_rtol = 100*eps()
 
 @testset "matrix multiplication" begin
@@ -35,23 +35,21 @@ end
     end
 end
 
-@testset "adjoint/transpose matrix multiplication" begin
-    for t in (adjoint, transpose)
-        @eval for i = 1:5
+@testset "adjoint matrix multiplication" begin
+        for i = 1:5
             A = sprand(ComplexF64, 5, 5, 0.2)
             b = rand(ComplexF64, 5)
-            outv = $t(A)*b
+            outv = A'*b
             c= zero(outv)
-            ioutv = imul!(copy(c), $t(A), b, 1, 1)[1]
+            ioutv = imul!(copy(c), A', b, 1, 1)[1]
             @test ≈(ioutv, outv, rtol=approx_rtol)
 
             B = rand(ComplexF64, 5, 3)
-            outm = $t(A)*B
+            outm = A'*B
             C = zero(outm)
-            ioutm = imul!(copy(C), $t(A), B, 1, 1)[1]
+            ioutm = imul!(copy(C), A', B, 1, 1)[1]
             @test ≈(ioutm, outm, rtol=approx_rtol)
         end
-    end
 end
 
 
@@ -85,5 +83,28 @@ end
         C = zero(outm)
         ioutm = imul!(copy(C), B', A, 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
         @test ≈(ioutm, outm, rtol=approx_rtol)
+    end
+end
+
+@testset "dense matrix - adjoint sparse matrix multiplication" begin
+    for i = 1:5
+        B = rand(10, 10)
+        A = sprand(5, 10, 0.5)
+        outm = B*A'
+        C = zero(outm)
+        ioutm = imul!(copy(C), B, A', 1 ,1)[1] # replace with imul!(similar(outv), A, b, 1, 1)[1]?
+        @test ≈(ioutm, outm, rtol=approx_rtol)
+    end
+end
+
+@testset "dense vector - sparse matrix dot" begin
+    for i = 1:5
+        x = rand(Float64, 10)
+        A = sprand(10, 5, 0.2)
+        y = rand(Float64, 5)
+        outd = dot(x, A, y)
+        r = zero(Float64)
+        ioutd = idot!(copy(r), x, A, y)[1]
+        @test ≈(ioutd, outd, rtol=approx_rtol)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using LinearAlgebra: include
+using Base: Float64
+using LinearAlgebra: include, eltype
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, ForwardDiff, SparseArrays
 using NiLang.AD

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 using NiSparseArrays
-using Test
-using LinearAlgebra
-
+using Test, Random, LinearAlgebra, NiLang, ForwardDiff, SparseArrays
+using NiLang.AD
 @testset "NiSparseArrays.jl" begin
     include("linalg.jl") #add sparse multiplication 
-    #include("sparsegrad.jl") #add sparse gradient test
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
+using LinearAlgebra: include
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, ForwardDiff, SparseArrays
 using NiLang.AD
 @testset "NiSparseArrays.jl" begin
+    include("utils.jl")
     include("linalg.jl") #add sparse multiplication 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using NiSparseArrays
 using Test
+using LinearAlgebra
 
 @testset "NiSparseArrays.jl" begin
-    # Write your tests here.
+    include("linalg.jl") #add sparse multiplication 
+    #include("sparsegrad.jl") #add sparse gradient test
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
-using SparseArrays: spmatmul
-using Base: Float64
-using LinearAlgebra: include, eltype
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, ForwardDiff, SparseArrays
 using NiLang.AD
+using BenchmarkTools
+using BenchmarkPlots, StatsPlots
 @testset "NiSparseArrays.jl" begin
     include("utils.jl")
     include("linalg.jl") #add sparse multiplication 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using SparseArrays: spmatmul
 using Base: Float64
 using LinearAlgebra: include, eltype
 using NiSparseArrays

--- a/test/sparsegrad.jl
+++ b/test/sparsegrad.jl
@@ -1,8 +1,0 @@
-using NiSparseArrays
-using SparseArrays
-using Test
-using ForwardDiff
-
-@testset "matrix-vector multiplication" begin
-    # write tests for gradient here
-end

--- a/test/sparsegrad.jl
+++ b/test/sparsegrad.jl
@@ -1,0 +1,8 @@
+using NiSparseArrays
+using SparseArrays
+using Test
+using ForwardDiff
+
+@testset "matrix-vector multiplication" begin
+    # write tests for gradient here
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,17 @@
+using NiSparseArrays:params, fitparams
+"""
+    forwarddiff_mv_jacobian(A, x) -> AbstractArray J 
+forwarddiff_mv_jacobian calculates the jacobian with respect to parameter A and x based on multiplication in ForwardDiff
+"""
+function forwarddiff_mm_jacobian(A, x)
+    pA = params(A)
+    px = params(x)
+    pAx = vcat(pA, px)
+    ForwardDiff.jacobian(pAx) do pAx
+        pA = pAx[1:length(pA)]
+        px = pAx[length(pA)+1:end]
+        A2 = fitparams(A, pA)
+        x2 = fitparams(x, px)
+        y = params(A2 * x2)
+    end
+end


### PR DESCRIPTION
In last PR from dev, I pointed that there may be performance gap between idot and [original implementation](https://github.com/JuliaLang/julia/blob/master/stdlib/SparseArrays/src/linalg.jl#L354) and the order of for-loop may influence the performance.

In my implementation, there triple for-loops while only one for-loop in original implementation since the calculation results of inner double for-loop in my program is equivalent to the _spdot in original implementation (but I couldn't find the source code of _spdot, so there may be some performance tricks here).

I test all the methods in my laptop (macOS intel i5)
Benchmark Performance on  idot(r, x::SparseVector, A::AbstractSparseMatrix{T1}, y::SparseVector{T2}) where {T1, T2}

- Benchmark on SparseArrays dot function:

``` julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  251.518 μs … 667.702 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     258.729 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   268.764 μs ±  29.530 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆█▇▇▆▄▄▃▂▁▁ ▁▁▁▁▁▁▁       ▁                                   ▂
  ████████████████████████▇█████▇█▇▇▇▇▇▇███▇▇▇▇▇▆▆▆▆▆▆▇▇▅▆▅▆▅▄▆ █
  252 μs        Histogram: log(frequency) by time        395 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

```

- Benchmark on NiSparseArrays idotxA function:

``` julia
BenchmarkTools.Trial: 2130 samples with 1 evaluation.
 Range (min … max):  2.174 ms …   7.712 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.256 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.327 ms ± 212.084 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆▄▁
  ████▆▇▆▆▄▅▄▄▄▅▅▄▄▄▃▄▃▄▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▃▃▂▂▂▂▂▂▂▁▂▂▁▂▂▂▂▂▂ ▃
  2.17 ms         Histogram: frequency by time        2.89 ms <

 Memory estimate: 224 bytes, allocs estimate: 4.

```

- Benchmark on NiSparseArrays idotAx function:

``` julia
BenchmarkTools.Trial: 1308 samples with 1 evaluation.
 Range (min … max):  2.953 ms … 40.413 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.714 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.781 ms ±  1.060 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

               ██▅▃▅▃▅▅▇▄▅▃▃▂▄▄▂▁
  ▃▁▁▁▁▂▁▃▁▂▂▁▁███████████████████▅▇▅▆▄▅▄▃▃▃▂▂▃▂▂▂▂▁▁▂▁▁▂▁▂▂ ▄
  2.95 ms        Histogram: frequency by time        4.89 ms <

 Memory estimate: 224 bytes, allocs estimate: 4.

```

In dev branch, I submitted the idotxA function since I think julia may do some acceleration on it just before I did benchmark tests (for each iteration ,x is always keep the same while A's column varies). However, there is still a relatively big performance gap between idotxA and dot. A more delicate implementation may be considered in the future.