### PR TITLE
[WIP] performance gap of imul on Adjoint(::Sparse)-dense

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,4 +1,4 @@
-using NiSparseArrays:imul!
+using NiSparseArrays:imul!, imul_v1!, imul_v2!
 const approx_rtol = 100*eps()
 
 @testset "matrix multiplication" begin
@@ -29,16 +29,22 @@ end
             b = rand(T, 5)
             outv = A'*b
             c= zero(outv)
-            ioutv = imul!(copy(c), A', b, 1, 1)[1]
-            @test check_inv(imul!, (copy(c), A', b, 1, 1))
-            @test ≈(ioutv, outv, rtol=approx_rtol)
+            ioutv1 = imul_v1!(copy(c), A', b, 1, 1)[1]
+            ioutv2 = imul_v2!(copy(c), A', b, 1, 1)[1]
+            @test check_inv(imul_v1!, (copy(c), A', b, 1, 1))
+            @test check_inv(imul_v2!, (copy(c), A', b, 1, 1))
+            @test ≈(ioutv1, outv, rtol=approx_rtol)
+            @test ≈(ioutv2, outv, rtol=approx_rtol)
 
             B = rand(T, 5, 3)
             outm = A'*B
             C = zero(outm)
-            ioutm = imul!(copy(C), A', B, 1, 1)[1]
-            @test check_inv(imul!, (copy(C), A', B, 1, 1))
-            @test ≈(ioutm, outm, rtol=approx_rtol)
+            ioutm1 = imul_v1!(copy(C), A', B, 1, 1)[1]
+            ioutm2 = imul_v2!(copy(C), A', B, 1, 1)[1]
+            @test check_inv(imul_v1!, (copy(C), A', B, 1, 1))
+            @test check_inv(imul_v2!, (copy(C), A', B, 1, 1))
+            @test ≈(ioutm1, outm, rtol=approx_rtol)
+            @test ≈(ioutm2, outm, rtol=approx_rtol)
         end
     end    
 end


### PR DESCRIPTION
This PR trys to figure out the performance gap of imul on Adjoint(::Sparse)-dense. (#13)
I just found I didn't multiply $\alpha$ in the initial version,  this is an primary error. 
After I revised the error,  I test the performance in my local machine, and the results are similar to the one johnny mentioned.

``` julia
julia> using SparseArrays

julia> using NiSparseArrays:imul_v1!, imul_v2!

julia> A = sprand(50,100,0.2);

julia> b = rand(50,50);

julia> C = zeros(100,50);

julia> using BenchmarkTools

julia> @btime A'*b
  34.339 μs (3 allocations: 39.19 KiB)
julia> @btime imul_v1!(C, A', b, 1.0, 1.0)
  71.151 μs (2 allocations: 128 bytes)
julia> @btime imul_v2!(C, A', b, 1.0, 1.0)
  64.665 μs (2 allocations: 128 bytes)
```