### PR TITLE
[WIP] add rrule 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 
 [targets]
-test = ["Test", "Random", "ForwardDiff"]
+test = ["Test", "Random", "ForwardDiff", "ChainRules"]

--- a/test/nirrule.jl
+++ b/test/nirrule.jl
@@ -1,0 +1,15 @@
+using ChainRules
+using NiSparseArrays:imul!
+
+function ChainRules.rrule(::typeof(imul!), C::StridedVecOrMat, A::AbstractSparseMatrix, B::DenseInputVecOrMat, α::Number, β::Number)
+    out = imul!(copy(C), A, B, α, β)[1]
+    function pullback(ȳ)
+        ChainRules.NoTangent(), grad((~imul!)(GVar(out, ȳ), GVar(C), GVar(A), GVar(B))[2])
+    end
+    out, pullback
+end
+
+# need to test
+# initialize A B C 1.0 1.0 
+# imul'(C, A, B, 1.0, 1.0) ≈ original_grad
+# what is original_grad? 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using LinearAlgebra: include
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, SparseArrays
 using NiLang.AD, ForwardDiff
@@ -6,4 +7,5 @@ using NiLang.AD, ForwardDiff
     include("linalg.jl")
     include("utils.jl") 
     include("jacobian.jl")
+    include("nirrule.jl")
 end


### PR DESCRIPTION
Try to add rrule but totally couldn't understand the official document provided by ChainRules.jl so it is just a draft.

``` julia
function ChainRules.rrule(::typeof(imul!), C::StridedVecOrMat, A::AbstractSparseMatrix, B::DenseInputVecOrMat, α::Number, β::Number)
    out = imul!(copy(C), A, B, α, β)[1]
    function pullback(ȳ)
        ChainRules.NoTangent(), grad((~imul!)(GVar(out, ȳ), GVar(C), GVar(A), GVar(B))[2])
    end
    out, pullback
end 
```
List some points I confused:
- Basic structure of the program
**return the out value and pullback** 
Similar to Dual number? But pullback should be seen as a linear operator mentioned in the meeting by  johnny?
Since C would be written in place in `imul!`, so when we calculate the out here,  should use of `copy( C)` not `C`? 
- Write the right pullback 
I still couldn't figure out the pullback function.
First,  it would return two output,  `ChainRules.NoTangent()` and `grad(...)`? What is the meaning of `ChainRules.NoTangent()` and why we need it?
Second
``` julia
 grad((~imul!)(GVar(out, ȳ), GVar(C), GVar(A), GVar(B))[2])
```
Just ignore `grad` and `Gvar`, `~imul!` means it will get `C` ( after computed ) and the other args as input and generate the original `C` and the other args before computation process?  Then we put `GVar` on the args and the gradient would be computed? But what would be the meaning and shape of gradient `A` and `B` ?
- Distinguish syntax between `NiLang` and `ChainRules`
Since I'm new to both the packages, so now I think chainrules provide rrule framework and NiLang just generate the local gradient and warpped by `pullback`?

- Write Test
I didn't even know what principle should be used to check the correctness of the chainrules. 

Finally,  CI failed in test because not using `DenseInputVecOrMat` from `SparseArrays` in test/ nirrule.jl. Correct it by copying and pasting from the snippet again?    