### PR TITLE
add rrule for `*(::Sparse, ::Dense)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,22 @@ authors = ["JieLi"]
 version = "0.1.0"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NiLang = "ab4ef3a6-0b42-11ea-31f6-e34652774712"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+ChainRulesCore = "1"
+NiLang = "0.9"
 julia = "1"
 
 [extras]
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "ForwardDiff"]
+test = ["ChainRulesTestUtils", "FiniteDifferences", "Test", "Random", "ForwardDiff"]

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -3,6 +3,10 @@ module NiSparseArrays
 using LinearAlgebra, SparseArrays
 using NiLang
 using NiLang.AD 
+using ChainRulesCore
 
+include("compat.jl")
 include("linalg.jl")
+include("chainrules.jl")
+
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,8 @@
+function ChainRulesCore.rrule(::typeof(*), A::AbstractSparseMatrix, B::DenseInputVecOrMat)
+    C = A * B
+    function mul_pullback(C̄)
+        _, i_A, i_B, _, _ = (~imul!)(AD.GVar(C, C̄), AD.GVar(A), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
+        return ChainRulesCore.NoTangent(), AD.grad(i_A), AD.grad(i_B)
+    end
+    return C, mul_pullback
+end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,9 @@
+if VERSION >= v"1.6"
+    # this union alias is added in https://github.com/JuliaLang/julia/pull/39557
+    using SparseArrays: DenseMatrixUnion, AdjOrTransDenseMatrix, DenseInputVector, DenseInputVecOrMat 
+else
+    const DenseMatrixUnion = Union{StridedMatrix, LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular, BitMatrix}
+    const AdjOrTransDenseMatrix = Union{DenseMatrixUnion,Adjoint{<:Any,<:DenseMatrixUnion},Transpose{<:Any,<:DenseMatrixUnion}}
+    const DenseInputVector = Union{StridedVector, BitVector}
+    const DenseInputVecOrMat = Union{AdjOrTransDenseMatrix, DenseInputVector}
+end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,4 +1,4 @@
-if VERSION >= v"1.6"
+@static if VERSION >= v"1.6"
     # this union alias is added in https://github.com/JuliaLang/julia/pull/39557
     using SparseArrays: DenseMatrixUnion, AdjOrTransDenseMatrix, DenseInputVector, DenseInputVecOrMat 
 else

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,15 +1,3 @@
-# declare struct 
-if VERSION >= v"1.6"
-    # this union alias is added in https://github.com/JuliaLang/julia/pull/39557
-    using SparseArrays: DenseMatrixUnion, AdjOrTransDenseMatrix, DenseInputVector, DenseInputVecOrMat 
-else
-    const DenseMatrixUnion = Union{StridedMatrix, LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular, BitMatrix}
-    const AdjOrTransDenseMatrix = Union{DenseMatrixUnion,Adjoint{<:Any,<:DenseMatrixUnion},Transpose{<:Any,<:DenseMatrixUnion}}
-    const DenseInputVector = Union{StridedVector, BitVector}
-    const DenseInputVecOrMat = Union{AdjOrTransDenseMatrix, DenseInputVector}
-end
-
-
 @i function imul!(C::StridedVecOrMat, A::AbstractSparseMatrix, B::DenseInputVecOrMat, α::Number, β::Number) 
     @safe size(A, 2) == size(B, 1) || throw(DimensionMismatch())
     @safe size(A, 1) == size(C, 1) || throw(DimensionMismatch())

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,15 @@
+@testset "test rrule" begin
+    @testset "mul" begin
+        # sparse * vector
+        A = sprand(5, 3, 0.5)
+        B = rand(3)
+        test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
+        # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+
+        # sparse * dense matrix
+        A = sprand(5, 3, 0.5)
+        B = rand(3, 2)
+        test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
+        # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,14 @@
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, SparseArrays
 using NiLang.AD, ForwardDiff
+using ChainRulesCore, ChainRulesTestUtils
+import FiniteDifferences
+
+include("testutils.jl")
 
 @testset "NiSparseArrays.jl" begin
     include("linalg.jl")
     include("utils.jl") 
     include("jacobian.jl")
+    include("chainrules.jl")
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,27 @@
+# ChainRulesTestUtils requires some method override to support sparse array
+# BEGIN ChainRulesTestUtils
+
+# we use this to generate Tangent and pass to test_rrule
+# for example: A ⊢ sprand_tangent(A)
+function sprand_tangent(A::AT) where AT<:SparseMatrixCSC
+    Ā = copy(A)
+    Ā.nzval .= rand(eltype(A), length(A.nzval))
+    return Tangent{AT}(Ā)
+end
+
+function Base.:(+)(a::P, b::Tangent{P}) where P<:SparseMatrixCSC
+    b[1] .+ a
+    return b
+end
+function FiniteDifferences.to_vec(A::AT) where AT<:SparseMatrixCSC
+    v = A.nzval
+    function SparseMatrixCSC_from_vec(v)
+        m = A.m
+        n = A.n
+        colptr = A.colptr
+        rowval = A.rowval
+        AT(m, n, colptr, rowval, v)
+    end
+    return v, SparseMatrixCSC_from_vec
+end
+# END ChainRulesTestUtils


### PR DESCRIPTION
I don't quite get what's the actual question #17 is, so here is a reference implementation.

ChainRulesTestUtils is used to test the gradients. There are some missing functions so I added them here to supply the test; those should better live in upstream packages (e.g., ChainRulesCore). `Thunk` type isn't supported by our `imul!` implementation so I skipped its test.