### PR TITLE
add support for complex cases

### DIFF
--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,8 +1,43 @@
-function ChainRulesCore.rrule(::typeof(*), A::AbstractSparseMatrix, B::DenseInputVecOrMat)
+function ChainRulesCore.rrule(
+    ::typeof(*), A::AbstractSparseMatrix{T}, B::DenseInputVecOrMat
+) where T 
     C = A * B
     function mul_pullback(C̄)
-        _, i_A, i_B, _, _ = (~imul!)(AD.GVar(C, C̄), AD.GVar(A), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
+        i_C, i_A, i_B, _, _ = (~imul!)(AD.GVar(C, unthunk(C̄)), AD.GVar(A), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
         return ChainRulesCore.NoTangent(), AD.grad(i_A), AD.grad(i_B)
+    end
+    return C, mul_pullback
+end
+
+function ChainRulesCore.rrule(
+    ::typeof(*), xA::Adjoint{T, <:AbstractSparseMatrix}, B::DenseInputVecOrMat
+) where T
+    C = xA * B
+    function mul_pullback(C̄)
+        _, i_xA, i_B, _, _ = (~imul!)(AD.GVar(C, C̄), AD.GVar(xA), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
+        return ChainRulesCore.NoTangent(), AD.grad(i_xA), AD.grad(i_B)
+    end
+    return C, mul_pullback
+end
+
+function ChainRulesCore.rrule(
+    ::typeof(*), X::DenseMatrixUnion,A::AbstractSparseMatrix{T}
+) where T 
+    C = X * A
+    function mul_pullback(C̄)
+        _, i_X, i_A, _, _ = (~imul!)(AD.GVar(C, C̄), AD.GVar(X), AD.GVar(A), AD.GVar(1.), AD.GVar(1.))
+        return ChainRulesCore.NoTangent(), AD.grad(i_X), AD.grad(i_A)
+    end
+    return C, mul_pullback
+end
+
+function ChainRulesCore.rrule(
+    ::typeof(*), X::Adjoint{T1, <:DenseMatrixUnion}, A::AbstractSparseMatrix{T2}
+) where {T1, T2} 
+    C = X * A
+    function mul_pullback(C̄)
+        _, i_X, i_A, _, _ = (~imul!)(AD.GVar(C, C̄), AD.GVar(X), AD.GVar(A), AD.GVar(1.), AD.GVar(1.))
+        return ChainRulesCore.NoTangent(), AD.grad(i_X), AD.grad(i_A)
     end
     return C, mul_pullback
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -3,7 +3,7 @@ function ChainRulesCore.rrule(
 ) where T 
     C = A * B
     function mul_pullback(C̄)
-        i_C, i_A, i_B, _, _ = (~imul!)(AD.GVar(C, unthunk(C̄)), AD.GVar(A), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
+        _, i_A, i_B, _, _ = (~imul!)(AD.GVar(C, unthunk(C̄)), AD.GVar(A), AD.GVar(B), AD.GVar(1.), AD.GVar(1.))
         return ChainRulesCore.NoTangent(), AD.grad(i_A), AD.grad(i_B)
     end
     return C, mul_pullback

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,7 +1,7 @@
 @testset "test rrule" begin
     @testset "matrix multiplication" begin
         # sparse * vector
-        for T in (ComplexF64, )
+        for T in (Float64, ComplexF64)
             A = sprand(T, 5, 3, 0.5)
             B = rand(T, 3)
             test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,15 +1,36 @@
 @testset "test rrule" begin
-    @testset "mul" begin
+    @testset "matrix multiplication" begin
         # sparse * vector
-        A = sprand(5, 3, 0.5)
-        B = rand(3)
-        test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
-        # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+        for T in (ComplexF64, )
+            A = sprand(T, 5, 3, 0.5)
+            B = rand(T, 3)
+            test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
+            # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
 
-        # sparse * dense matrix
-        A = sprand(5, 3, 0.5)
-        B = rand(3, 2)
-        test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
-        # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+            # sparse * dense matrix
+            A = sprand(T, 5, 3, 0.5)
+            B = rand(T, 3, 2)
+            test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
+            test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+        end 
+    end
+
+    @testset "dense matrix-sparse matrix multiplication" begin
+        # dense matrix * sparse matrix
+        for T in (Float64, ComplexF64)
+            B = rand(T, 10, 10)
+            A = sprand(T, 10, 5, 0.5)
+            test_rrule(*, B, A ⊢ sprand_tangent(A); check_thunked_output_tangent=false)
+        end 
+    end
+
+    @testset "adjoint dense matrix-sparse matrix multiplication" begin
+    #     # adjoint dense matrix * sparse matrix
+        for T in (Float64, ComplexF64)
+            B = rand(T, 10, 5)
+            A = sprand(T, 10, 5, 0.5)
+            test_rrule(*, B', A ⊢ sprand_tangent(A); check_thunked_output_tangent=false)
+        end 
     end
 end
+

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -11,9 +11,22 @@
             A = sprand(T, 5, 3, 0.5)
             B = rand(T, 3, 2)
             test_rrule(*, A ⊢ sprand_tangent(A), B; check_thunked_output_tangent=false)
-            test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
+            # test_rrule(*, A ⊢ sprand_tangent(A), B) # FIXME: Thunk doesn't yet supported.
         end 
     end
+
+    @testset "adjoint matrix multiplication" begin
+        for T in (Float64, ComplexF64)
+            A = sprand(T, 5, 5, 0.2)
+            b = rand(T, 5)
+            test_rrule(*, A' ⊢ sprand_tangent(A'), b; check_thunked_output_tangent=false)
+
+            A = sprand(T, 5, 5, 0.2)
+            B = rand(T, 5, 3)
+            test_rrule(*, A' ⊢ sprand_tangent(A'), B; check_thunked_output_tangent=false)
+        end
+    end
+
 
     @testset "dense matrix-sparse matrix multiplication" begin
         # dense matrix * sparse matrix

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,6 @@ import FiniteDifferences
 include("testutils.jl")
 
 @testset "NiSparseArrays.jl" begin
-    include("linalg.jl")
+    #include("linalg.jl")
     include("chainrules.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,6 @@ import FiniteDifferences
 include("testutils.jl")
 
 @testset "NiSparseArrays.jl" begin
-    #include("linalg.jl")
+    include("linalg.jl")
     include("chainrules.jl")
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -9,10 +9,16 @@ function sprand_tangent(A::AT) where AT<:SparseMatrixCSC
     return Tangent{AT}(Ā)
 end
 
+function sprand_tangent(A::Adjoint{T, <:AbstractSparseMatrix}) where T
+    Ā = copy(A)
+    return sprand_tangent(Ā)
+end
+
 function Base.:(+)(a::P, b::Tangent{P}) where P<:SparseMatrixCSC
     b[1] .+ a
     return b
 end
+
 function FiniteDifferences.to_vec(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}
     v = reinterpret(real(Tv), A.nzval)
     function SparseMatrixCSC_from_vec(v)
@@ -24,6 +30,11 @@ function FiniteDifferences.to_vec(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}
         SparseMatrixCSC(m, n, colptr, rowval, cv)
     end
     return v, SparseMatrixCSC_from_vec
+end
+
+function FiniteDifferences.to_vec(A::Adjoint{T, <:AbstractSparseMatrix}) where T
+    Ā = copy(A)
+    return FiniteDifferences.to_vec(Ā)
 end
 
 function FiniteDifferences._j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Complex})

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -13,15 +13,24 @@ function Base.:(+)(a::P, b::Tangent{P}) where P<:SparseMatrixCSC
     b[1] .+ a
     return b
 end
-function FiniteDifferences.to_vec(A::AT) where AT<:SparseMatrixCSC
-    v = A.nzval
+function FiniteDifferences.to_vec(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}
+    v = reinterpret(real(Tv), A.nzval)
     function SparseMatrixCSC_from_vec(v)
         m = A.m
         n = A.n
         colptr = A.colptr
         rowval = A.rowval
-        AT(m, n, colptr, rowval, v)
+        cv = Vector(reinterpret(Tv, v))
+        SparseMatrixCSC(m, n, colptr, rowval, cv)
     end
     return v, SparseMatrixCSC_from_vec
 end
+
+function FiniteDifferences._j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Complex})
+    isempty(x) && return eltype(ȳ)[] # if x is empty, then so is the jacobian and x̄
+    r_jcb = transpose(first(FiniteDifferences.jacobian(fdm, f, real(x)))) * real(ȳ)
+    i_jcb = transpose(first(FiniteDifferences.jacobian(fdm, f, imag(x)))) * imag(ȳ)
+    return Complex(r_jcb, i_jcb)
+end
+
 # END ChainRulesTestUtils


### PR DESCRIPTION
Support has been added for complex cases. However, johnny and I found NiLang.AD should extend GVar type to thunk type.
[thunk type](https://github.com/JuliaDiff/ChainRulesCore.jl/blob/8218c2cbb24492664f5d4db6e7a41c147f5472d7/src/differentials/thunks.jl#L1)
And may be I could help to add GVar extension.
In this PR, I use unthunk to get the original type to avoid CI failed.