### PR TITLE
sparse vector dot rrule failed some cases

### DIFF
--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -63,3 +63,14 @@ function ChainRulesCore.rrule(
     end
     return r, dot_pullback
 end
+
+function ChainRulesCore.rrule(
+    ::typeof(dot), x::SparseVector, A::AbstractSparseMatrix{T1}, y::SparseVector{T2}
+) where {T1, T2}
+    r = dot(x, A, y)
+    function dot_pullback(r̄)
+        _, i_x, i_A, i_y = (~idot)(AD.GVar(r, r̄), AD.GVar(x), AD.GVar(A), AD.GVar(y))
+        return ChainRulesCore.NoTangent(), AD.grad(i_x), AD.grad(i_A), AD.grad(i_y)
+    end
+    return r, dot_pullback
+end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -179,15 +179,15 @@ end
     @safe length(x) == size(A, 1) || throw(DimensionMismatch())
     @safe length(y) == size(A, 2) || throw(DimensionMismatch())
 
-    @invcheckoff for (yi, yv) in zip(y.nzind, y.nzval)
-        for (xi, xv) in  zip(x.nzind, x.nzval)
-            for k in nzrange(A, yi)
-                if A.rowval[k] == xi
+    @invcheckoff for m in 1:nnz(y) 
+        for j in  1:nnz(x) 
+            for k in nzrange(A, y.nzind[m])
+                if A.rowval[k] == x.nzind[j]
                     @routine begin
                         anc ← zero(promote_type(T1, T2))
-                        anc += A.nzval[k] * yv
+                        anc += A.nzval[k] * y.nzval[m]
                     end
-                    r += xv' * anc
+                    r += x.nzval[j]' * anc
                     ~@routine
                 end
             end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -63,5 +63,13 @@
         end
     end
 
+    @testset "sparse vector - sparse matrix dot" begin
+        for T in (Float64, ComplexF64)
+            x = sprand(T, 10, 0.2)
+            A = sprand(T, 10, 5, 0.2)
+            y = sprand(T, 5, 0.3)
+            test_rrule(dot, x ⊢ sprand_tangent(x), A ⊢ sprand_tangent(A), y ⊢ sprand_tangent(y); check_thunked_output_tangent=false)
+        end
+    end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -96,6 +96,7 @@ end
             outd = dot(x, A, y)
             r = zero(T)
             ioutd = idot(r, x, A, y)[1]
+            @test check_inv(idot, (r, x, A, y))
             @test ≈(ioutd, outd, rtol=approx_rtol)
         end
     end
@@ -110,6 +111,7 @@ end
             outd = dot(x, A, y)
             r = zero(T)
             ioutd = idot(r, x, A, y)[1]
+            @test check_inv(idot, (r, x, A, y))
             @test ≈(ioutd, outd, rtol=approx_rtol)
         end
     end
@@ -123,6 +125,7 @@ end
             outd = dot(A, B)
             r = zero(T)
             ioutd = idot(r, A, B)[1]
+            @test check_inv(idot, (r, A, B))
             @test ≈(ioutd, outd, rtol=approx_rtol)
         end
     end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -35,6 +35,17 @@ function FiniteDifferences.to_vec(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti}
     return v, SparseMatrixCSC_from_vec
 end
 
+function FiniteDifferences.to_vec(x::SparseVector{Tv, Ti}) where {Tv, Ti}
+    v= reinterpret(real(Tv), x.nzval)
+    function SparseVector_from_vec(v)
+        n = x.n
+        nzind = x.nzind
+        cv = Vector(reinterpret(Tv, v))
+        SparseVector(n, nzind, cv)
+    end
+    return v, SparseVector_from_vec
+end
+
 function FiniteDifferences.to_vec(A::Adjoint{T, <:AbstractSparseMatrix}) where T
     Ā = copy(A)
     return FiniteDifferences.to_vec(Ā)


### PR DESCRIPTION
It is strange that `rrule` on `dot(x::SparseVector, A::AbstractSparseMatrix{T1}, y::SparseVector{T2}) where {T1, T2}` failed in some cases. 

Check out `jl/sparse-dot` branch by

``` shell
git checkout jl/sparse-dot
```

Then open an REPL and type `]` into pkg mode

``` shell
pkg> activate .
```

``` julia
julia> using NiSparseArrays

julia> using Test, Random, LinearAlgebra, NiLang, SparseArrays

julia> using NiLang.AD

julia> using ChainRulesCore, ChainRulesTestUtils

julia> import FiniteDifferences

julia> include("test/testutils.jl")

julia> @testset "sparse vector - sparse matrix dot" begin
               for T in (Float64, ComplexF64)
                   x = sprand(T, 10, 0.2)
                   A = sprand(T, 10, 5, 0.2)
                   y = sprand(T, 5, 0.3)
                   test_rrule(dot, x ⊢ sprand_tangent(x), A ⊢ sprand_tangent(A), y ⊢ sprand_tangent(y); check_thunked_output_tangent=false)
               end
           end
```

sparse vector dot rrule would fail in some cases. I should emphasize it that it is not a syntax error but test-cases error (just failed on some specific cases). It may be passed in the local machine if you type the codes above,  but CI results would tell you more information and I think it is hard for me to describe it in words.

``` julia
sparse vector - sparse matrix dot                                                                                       |   18     2     20
      test_rrule: dot on SparseVector{Float64, Int64},SparseMatrixCSC{Float64, Int64},SparseVector{Float64, Int64}          |   10           10
      test_rrule: dot on SparseVector{ComplexF64, Int64},SparseMatrixCSC{ComplexF64, Int64},SparseVector{ComplexF64, Int64} |    8     2     10  
```

Clues:

1. Both `Complex` and `Float` cases would fail. 
2. I had tested the implementation of `idot` in large scale and it never errored. So maybe we should focus on the implementation of `FiniteDifferences.to_vec(x::SparseVector{Tv, Ti}) where {Tv, Ti}.`
3. I try to figure out why ` 0 stored entry ` appears.


cc: @GiggleLiu  @johnnychen94 