### PR TITLE
low rank svd on sparse matrix

### DIFF
--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,5 +1,6 @@
 module NiSparseArrays
 
+using ChainRulesCore: include
 using Base: promote_eltype
 using LinearAlgebra
 using SparseArrays
@@ -10,5 +11,5 @@ using ChainRulesCore
 include("compat.jl")
 include("linalg.jl")
 include("chainrules.jl")
-
+include("lowranksvd.jl")
 end

--- a/src/lowranksvd.jl
+++ b/src/lowranksvd.jl
@@ -1,0 +1,43 @@
+# Low Rank Singular Value Decomposition
+"""
+    get_approximate_basis(A, l::Int; niter::Int = 2, M = nothing) -> Q
+Return Matrix ``Q`` with ``l`` orthonormal columns such that ``Q Q^H A`` approximates ``A``. If ``M`` is specified, then ``Q`` is such that ``Q Q^H (A - M)`` approximates ``A - M``.
+"""
+
+function get_approximate_basis(
+    A::AbstractSparseMatrix{T}, l::Int, niter::Int = 2, M::Union{AbstractSparseMatrix{T}, Nothing} = nothing) where T
+    m, n = size(A)
+    Ω = rand(T, (n, l))
+    if M === nothing 
+        F_j = qr(A * Ω)
+        for j = 1:niter
+            F_H_j = qr(A' * Matrix(F_j.Q))
+            F_j = qr(A * Matrix(F_H_j.Q))
+        end
+    else
+        F_j = qr(A * Ω - M * Ω)
+        for j = 1:niter
+            F_H_j = qr(A' * Matrix(F_j.Q) - M' * Matrix(F_j.Q))
+            F_j = qr(A * Matrix(F_H_j.Q) - M * Matrix(F_H_j.Q))
+        end
+    end
+    Matrix(F_j.Q)
+end
+
+"""
+    low_rank_svd(A, l::Int; niter::Int = 2, M = nothing) -> U, S, Vt
+Return the singular value decomposition LowRankSVD(U, S, Vt) of a matrix or a sparse matrix ``A`` such that ``A ≈ U diag(S) Vt``. In case ``M`` is given, then SVD is computed for the matrix ``A - M``.
+"""
+
+function low_rank_svd(A::AbstractSparseMatrix{T}, l::Int, niter::Int = 2, M::Union{AbstractSparseMatrix{T}, Nothing} = nothing) where T
+    Q = get_approximate_basis(A, l, niter, M)
+    if M === nothing
+        B = Q' * A
+    else
+        B = Q' * (A - M)
+    end
+
+    dense_svd = svd(B)
+    U = Q * dense_svd.U
+    return U, dense_svd.S, dense_svd.Vt
+end

--- a/src/lowranksvd.jl
+++ b/src/lowranksvd.jl
@@ -30,10 +30,13 @@ Return the singular value decomposition LowRankSVD(U, S, Vt) of a matrix or a sp
 """
 
 function low_rank_svd(A::AbstractSparseMatrix{T}, l::Int, niter::Int = 2, M::Union{AbstractSparseMatrix{T}, Nothing} = nothing) where T
-    Q = get_approximate_basis(A, l, niter, M)
+    
     if M === nothing
+        Q = get_approximate_basis(A, l, niter, M)
         B = Q' * A
     else
+        M = M .- zero(A)
+        Q = get_approximate_basis(A, l, niter, M)
         B = Q' * (A - M)
     end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,6 +1,4 @@
-using Test, SparseArrays, LinearAlgebra
 using NiSparseArrays:imul!, idot
-using NiLang
 const approx_rtol = 100*eps()
 
 @testset "matrix multiplication" begin

--- a/test/lowranksvd.jl
+++ b/test/lowranksvd.jl
@@ -1,0 +1,22 @@
+using NiSparseArrays:get_approximate_basis, low_rank_svd
+@testset "low rank svd" begin
+    for T in (Float64, ComplexF64)
+        approx_rtol = 100*eps(real(T))
+        for (n, m) in ((64,32), (32,32))
+            for i = 1:5
+                A = sprand(n, m, 0.1)
+                r = rank(A) # sparse matrix not always low rank 
+                @testset "Q basis" begin
+                    Q = get_approximate_basis(A, r)
+                    @test norm(A - Q*Q'*A) < approx_rtol*norm(A)
+                end
+                
+                @testset "svd test" begin
+                    U, S, Vt = low_rank_svd(A, r)
+                    A_approx = U * Diagonal(S) * Vt
+                    @test norm(A - A_approx) < approx_rtol*norm(A)
+                end
+            end    
+        end
+    end
+end

--- a/test/lowranksvd.jl
+++ b/test/lowranksvd.jl
@@ -6,15 +6,29 @@ using NiSparseArrays:get_approximate_basis, low_rank_svd
             for i = 1:5
                 A = sprand(n, m, 0.1)
                 r = rank(A) # sparse matrix not always low rank 
-                @testset "Q basis" begin
+                @testset "Q basis for A" begin
                     Q = get_approximate_basis(A, r)
                     @test norm(A - Q*Q'*A) < approx_rtol*norm(A)
                 end
                 
-                @testset "svd test" begin
+                @testset "svd test for A" begin
                     U, S, Vt = low_rank_svd(A, r)
                     A_approx = U * Diagonal(S) * Vt
                     @test norm(A - A_approx) < approx_rtol*norm(A)
+                end
+
+                M = sprand(n, m, 0.1)
+                A_m = A - M
+                r_m = rank(A-M)
+                @testset "Q basis for A - M" begin
+                    Q = get_approximate_basis(A, r_m, 2, M)
+                    @test norm(A_m - Q*Q'*A_m) < approx_rtol*norm(A_m)
+                end
+                
+                @testset "svd test for A - M" begin
+                    U, S, Vt = low_rank_svd(A, r_m, 2, M)
+                    A_m_approx = U * Diagonal(S) * Vt
+                    @test norm(A_m - A_m_approx) < approx_rtol*norm(A_m)
                 end
             end    
         end

--- a/test/lowranksvd.jl
+++ b/test/lowranksvd.jl
@@ -17,9 +17,9 @@ using NiSparseArrays:get_approximate_basis, low_rank_svd
                     @test norm(A - A_approx) < approx_rtol*norm(A)
                 end
 
-                M = sprand(n, m, 0.1)
-                A_m = A - M
-                r_m = rank(A-M)
+                M = rand(1, m)
+                A_m = A .- M 
+                r_m = rank(A_m)
                 @testset "Q basis for A - M" begin
                     Q = get_approximate_basis(A, r_m, 2, M)
                     @test norm(A_m - Q*Q'*A_m) < approx_rtol*norm(A_m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using ChainRulesCore: include
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, SparseArrays
 using NiLang.AD, ForwardDiff
@@ -9,4 +10,5 @@ include("testutils.jl")
 @testset "NiSparseArrays.jl" begin
     include("linalg.jl")
     include("chainrules.jl")
+    include("lowranksvd.jl")
 end


### PR DESCRIPTION
实现稀疏矩阵的低秩分解，需要强调的是，稀疏不一定低秩，因此测试中显式地计算了矩阵的秩，错误地估计稀疏矩阵秩会导致误差过大无法通过测试。
待完成的为微分部分