### PR TITLE
[Review]: rrule on qr

### DIFF
--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,5 +1,6 @@
 module NiSparseArrays
 
+using ChainRulesCore: include
 using Base: promote_eltype
 using LinearAlgebra
 using SparseArrays
@@ -10,5 +11,5 @@ using ChainRulesCore
 include("compat.jl")
 include("linalg.jl")
 include("chainrules.jl")
-
+include("lowranksvd.jl")
 end

--- a/src/NiSparseArrays.jl
+++ b/src/NiSparseArrays.jl
@@ -1,6 +1,5 @@
 module NiSparseArrays
 
-using ChainRulesCore: include
 using Base: promote_eltype
 using LinearAlgebra
 using SparseArrays
@@ -10,6 +9,7 @@ using ChainRulesCore
 
 include("compat.jl")
 include("linalg.jl")
-include("chainrules.jl")
 include("lowranksvd.jl")
+include("srcutils.jl")
+include("chainrules.jl")
 end

--- a/src/lowranksvd.jl
+++ b/src/lowranksvd.jl
@@ -1,0 +1,43 @@
+# Low Rank Singular Value Decomposition
+"""
+    get_approximate_basis(A, l::Int; niter::Int = 2, M = nothing) -> Q
+Return Matrix ``Q`` with ``l`` orthonormal columns such that ``Q Q^H A`` approximates ``A``. If ``M`` is specified, then ``Q`` is such that ``Q Q^H (A - M)`` approximates ``A - M``.
+"""
+
+function get_approximate_basis(
+    A::AbstractSparseMatrix{T}, l::Int, niter::Int = 2, M::Union{AbstractSparseMatrix{T}, Nothing} = nothing) where T
+    m, n = size(A)
+    Ω = rand(T, (n, l))
+    if M === nothing 
+        F_j = qr(A * Ω)
+        for j = 1:niter
+            F_H_j = qr(A' * Matrix(F_j.Q))
+            F_j = qr(A * Matrix(F_H_j.Q))
+        end
+    else
+        F_j = qr(A * Ω - M * Ω)
+        for j = 1:niter
+            F_H_j = qr(A' * Matrix(F_j.Q) - M' * Matrix(F_j.Q))
+            F_j = qr(A * Matrix(F_H_j.Q) - M * Matrix(F_H_j.Q))
+        end
+    end
+    Matrix(F_j.Q)
+end
+
+"""
+    low_rank_svd(A, l::Int; niter::Int = 2, M = nothing) -> U, S, Vt
+Return the singular value decomposition LowRankSVD(U, S, Vt) of a matrix or a sparse matrix ``A`` such that ``A ≈ U diag(S) Vt``. In case ``M`` is given, then SVD is computed for the matrix ``A - M``.
+"""
+
+function low_rank_svd(A::AbstractSparseMatrix{T}, l::Int, niter::Int = 2, M::Union{AbstractSparseMatrix{T}, Nothing} = nothing) where T
+    Q = get_approximate_basis(A, l, niter, M)
+    if M === nothing
+        B = Q' * A
+    else
+        B = Q' * (A - M)
+    end
+
+    dense_svd = svd(B)
+    U = Q * dense_svd.U
+    return U, dense_svd.S, dense_svd.Vt
+end

--- a/src/lowranksvd.jl
+++ b/src/lowranksvd.jl
@@ -4,12 +4,12 @@
 Return Matrix ``Q`` with ``l`` orthonormal columns such that ``Q Q^H A`` approximates ``A``. If ``M`` is specified, then ``Q`` is such that ``Q Q^H (A - M)`` approximates ``A - M``.
 """
 
-struct Normal_QR
-    Q::AbstractArray
-    R::AbstractArray
-    function Normal_QR(Q, R)
+struct Normal_QR{QT, RT}
+    Q::QT
+    R::RT
+    function Normal_QR(Q::QT, R::RT) where {QT<:AbstractMatrix, RT<:AbstractMatrix}
         size(Q, 2) == size(R, 1) || throw(DimensionMismatch("$(size(Q)), $(length(R)) not compatible"))
-        new(Q, R)
+        new{QT, RT}(Q, R)
     end
 end
 

--- a/src/srcutils.jl
+++ b/src/srcutils.jl
@@ -1,0 +1,18 @@
+trtrs!(c1::Char, c2::Char, c3::Char, r::AbstractMatrix, b::AbstractVecOrMat) = LinearAlgebra.LAPACK.trtrs!(c1, c2, c3, r, b)
+
+"""
+    copyltu!(A::AbstractMatrix) -> AbstractMatrix
+copy the lower triangular to upper triangular.
+"""
+function copyltu!(A::AbstractMatrix)
+    m, n = size(A)
+    for i=1:m
+        A[i,i] = real(A[i,i])
+        for j=i+1:n
+            @inbounds A[i,j] = conj(A[j,i])
+        end
+    end
+    A
+end
+
+do_adjoint(A::Matrix) = Matrix(A')

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,3 +1,4 @@
+using NiSparseArrays:private_qr
 @testset "test rrule" begin
     @testset "matrix multiplication" begin
         # sparse * vector
@@ -69,6 +70,14 @@
             A = sprand(T, 10, 5, 0.2)
             y = sprand(T, 5, 0.3)
             test_rrule(dot, x ⊢ sprand_tangent(x), A ⊢ sprand_tangent(A), y ⊢ sprand_tangent(y); check_thunked_output_tangent=false)
+        end
+    end
+
+    @testset "qr decomposition" begin
+        for size in [(4, 4), (7, 4), (19, 5), (44, 17)]
+            m,n = size
+            X = randn(n,m)
+            test_rrule(private_qr, X; check_thunked_output_tangent=false)
         end
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,6 +1,4 @@
-using Test, SparseArrays, LinearAlgebra
 using NiSparseArrays:imul!, idot
-using NiLang
 const approx_rtol = 100*eps()
 
 @testset "matrix multiplication" begin

--- a/test/lowranksvd.jl
+++ b/test/lowranksvd.jl
@@ -1,0 +1,22 @@
+using NiSparseArrays:get_approximate_basis, low_rank_svd
+@testset "low rank svd" begin
+    for T in (Float64, ComplexF64)
+        approx_rtol = 100*eps(real(T))
+        for (n, m) in ((64,32), (32,32))
+            for i = 1:5
+                A = sprand(n, m, 0.1)
+                r = rank(A) # sparse matrix not always low rank 
+                @testset "Q basis" begin
+                    Q = get_approximate_basis(A, r)
+                    @test norm(A - Q*Q'*A) < approx_rtol*norm(A)
+                end
+                
+                @testset "svd test" begin
+                    U, S, Vt = low_rank_svd(A, r)
+                    A_approx = U * Diagonal(S) * Vt
+                    @test norm(A - A_approx) < approx_rtol*norm(A)
+                end
+            end    
+        end
+    end
+end

--- a/test/lowranksvd.jl
+++ b/test/lowranksvd.jl
@@ -6,15 +6,29 @@ using NiSparseArrays:get_approximate_basis, low_rank_svd
             for i = 1:5
                 A = sprand(n, m, 0.1)
                 r = rank(A) # sparse matrix not always low rank 
-                @testset "Q basis" begin
+                @testset "Q basis for A" begin
                     Q = get_approximate_basis(A, r)
                     @test norm(A - Q*Q'*A) < approx_rtol*norm(A)
                 end
                 
-                @testset "svd test" begin
+                @testset "svd test for A" begin
                     U, S, Vt = low_rank_svd(A, r)
                     A_approx = U * Diagonal(S) * Vt
                     @test norm(A - A_approx) < approx_rtol*norm(A)
+                end
+
+                M = sprand(n, m, 0.1)
+                A_m = A - M
+                r_m = rank(A-M)
+                @testset "Q basis for A - M" begin
+                    Q = get_approximate_basis(A, r_m, 2, M)
+                    @test norm(A_m - Q*Q'*A_m) < approx_rtol*norm(A_m)
+                end
+                
+                @testset "svd test for A - M" begin
+                    U, S, Vt = low_rank_svd(A, r_m, 2, M)
+                    A_m_approx = U * Diagonal(S) * Vt
+                    @test norm(A_m - A_m_approx) < approx_rtol*norm(A_m)
                 end
             end    
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using ChainRulesCore: include
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, SparseArrays
 using NiLang.AD, ForwardDiff
@@ -9,4 +10,5 @@ include("testutils.jl")
 @testset "NiSparseArrays.jl" begin
     include("linalg.jl")
     include("chainrules.jl")
+    include("lowranksvd.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,16 @@ using NiLang.AD, ForwardDiff
 using ChainRulesCore, ChainRulesTestUtils
 import FiniteDifferences
 
+using NiSparseArrays: Normal_QR
+function ChainRulesTestUtils.test_approx(actual::Normal_QR, expected::Normal_QR, msg=""; kwargs...)
+    ChainRulesTestUtils.test_approx(actual.Q, expected.Q, msg; kwargs...)
+    ChainRulesTestUtils.test_approx(actual.R, expected.R, msg; kwargs...)
+end
+
 include("testutils.jl")
 
 @testset "NiSparseArrays.jl" begin
-    #include("linalg.jl")
+    include("linalg.jl")
     include("chainrules.jl")
     include("lowranksvd.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using ChainRulesCore: include
 using NiSparseArrays
 using Test, Random, LinearAlgebra, NiLang, SparseArrays
 using NiLang.AD, ForwardDiff
@@ -8,7 +7,7 @@ import FiniteDifferences
 include("testutils.jl")
 
 @testset "NiSparseArrays.jl" begin
-    include("linalg.jl")
+    #include("linalg.jl")
     include("chainrules.jl")
     include("lowranksvd.jl")
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -54,8 +54,8 @@ function FiniteDifferences.to_vec(A::Adjoint{T, <:AbstractSparseMatrix}) where T
 end
 
 function FiniteDifferences.to_vec(x::S) where {S <: Normal_QR }
-    q_vec, q_back = to_vec(x.Q)
-    r_vec, r_back = to_vec(x.R)
+    q_vec, q_back = FiniteDifferences.to_vec(x.Q)
+    r_vec, r_back = FiniteDifferences.to_vec(x.R)
     function Normal_QR_from_vec(v)
         Q_new = q_back(v.Q)
         R_new = r_back(v.R)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -3,6 +3,8 @@
 
 # we use this to generate Tangent and pass to test_rrule
 # for example: A ⊢ sprand_tangent(A)
+using NiSparseArrays:Normal_QR
+
 function sprand_tangent(A::AT) where AT<:SparseMatrixCSC
     return ChainRulesTestUtils.rand_tangent(A)
 end
@@ -49,6 +51,17 @@ end
 function FiniteDifferences.to_vec(A::Adjoint{T, <:AbstractSparseMatrix}) where T
     Ā = copy(A)
     return FiniteDifferences.to_vec(Ā)
+end
+
+function FiniteDifferences.to_vec(x::S) where {S <: Normal_QR }
+    q_vec, q_back = to_vec(x.Q)
+    r_vec, r_back = to_vec(x.R)
+    function Normal_QR_from_vec(v)
+        Q_new = q_back(v.Q)
+        R_new = r_back(v.R)
+        return S(Q_new, R_new)
+    end
+    return [q_vec; r_vec], Normal_QR_from_vec
 end
 
 function FiniteDifferences._j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Complex})


### PR DESCRIPTION
之前他人在`ChainRules`提的`qr_rrule`的PR[https://github.com/JuliaDiff/ChainRules.jl/pull/469]中，`ChainRules`版本过低，与`NiSparseArrays`里其他`rrule`函数无法兼容，因此需要重新改写。
改写后进行`test_rrule`测试发现如下报错:
``` julia
julia> git checkout jl/privateqr
julia> test
test_rrule: private_qr on Matrix{Float64}: Error During Test at /Users/lijie/.julia/packages/ChainRulesTestUtils/Rzheq/src/testers.jl:191
  Got exception outside of a @test
  MethodError: no method matching length(::Normal_QR)
  Closest candidates are:
    length(::Union{Base.KeySet, Base.ValueIterator}) at abstractdict.jl:58
    length(::Union{Adjoint{T, var"#s6"} where var"#s6"<:Union{StaticArrays.StaticVector{var"#s1", T} where var"#s1", StaticArrays.StaticMatrix{var"#s4", var"#s5", T} where {var"#s4", var"#s5"}}, Diagonal{T, var"#s13"} where var"#s13"<:(StaticArrays.StaticVector{var"#s14", T} where var"#s14"), Hermitian{T, var"#s10"} where var"#s10"<:(StaticArrays.StaticMatrix{var"#s11", var"#s12", T} where {var"#s11", var"#s12"}), LowerTriangular{T, var"#s18"} where var"#s18"<:(StaticArrays.StaticMatrix{var"#s19", var"#s20", T} where {var"#s19", var"#s20"}), Symmetric{T, var"#s7"} where var"#s7"<:(StaticArrays.StaticMatrix{var"#s8", var"#s9", T} where {var"#s8", var"#s9"}), Transpose{T, var"#s1"} where var"#s1"<:Union{StaticArrays.StaticVector{var"#s1", T} where var"#s1", StaticArrays.StaticMatrix{var"#s4", var"#s5", T} where {var"#s4", var"#s5"}}, UnitLowerTriangular{T, var"#s24"} where var"#s24"<:(StaticArrays.StaticMatrix{var"#s25", var"#s26", T} where {var"#s25", var"#s26"}), UnitUpperTriangular{T, var"#s21"} where var"#s21"<:(StaticArrays.StaticMatrix{var"#s22", var"#s23", T} where {var"#s22", var"#s23"}), UpperTriangular{T, var"#s15"} where var"#s15"<:(StaticArrays.StaticMatrix{var"#s16", var"#s17", T} where {var"#s16", var"#s17"}), StaticArrays.StaticVector{var"#s26", T} where var"#s26", StaticArrays.StaticMatrix{var"#s5", var"#s4", T} where {var"#s5", var"#s4"}, StaticArrays.StaticArray{var"#s26", T, N} where {var"#s26"<:Tuple, N}} where T) at /Users/lijie/.julia/packages/StaticArrays/vxjOO/src/abstractarray.jl:1
    length(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:195
    ...
  Stacktrace:
    [1] _similar_for(c::UnitRange{Int64}, #unused#::Type{Any}, itr::Normal_QR, #unused#::Base.HasLength)
      @ Base ./array.jl:575
    [2] _collect(cont::UnitRange{Int64}, itr::Normal_QR, #unused#::Base.HasEltype, isz::Base.HasLength)
      @ Base ./array.jl:608
    [3] collect(itr::Normal_QR)
      @ Base ./array.jl:602
    [4] test_approx(actual::Normal_QR, expected::Normal_QR, msg::Any; kwargs::Any)
      @ ChainRulesTestUtils ~/.julia/packages/ChainRulesTestUtils/Rzheq/src/check_result.jl:141
    [5] macro expansion
      @ ~/.julia/packages/ChainRulesTestUtils/Rzheq/src/testers.jl:205 [inlined]
    [6] macro expansion
      @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [7] test_rrule(config::RuleConfig, f::Any, args::Any; output_tangent::Any, check_thunked_output_tangent::Any, fdm::Any, rrule_f::Any, check_inferred::Bool, fkwargs::NamedTuple, rtol::Real, atol::Real, kwargs::Any)
      @ ChainRulesTestUtils ~/.julia/packages/ChainRulesTestUtils/Rzheq/src/testers.jl:194
    [8] #test_rrule#47
      @ ~/.julia/packages/ChainRulesTestUtils/Rzheq/src/testers.jl:168 [inlined]
    [9] macro expansion
      @ ~/Fudan/git/NiSparseArrays.jl/test/chainrules.jl:80 [inlined]
   [10] macro expansion
      @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [11] macro expansion
      @ ~/Fudan/git/NiSparseArrays.jl/test/chainrules.jl:77 [inlined]
   [12] macro expansion
      @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [13] top-level scope
      @ ~/Fudan/git/NiSparseArrays.jl/test/chainrules.jl:3
   [14] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [15] macro expansion
      @ ~/Fudan/git/NiSparseArrays.jl/test/runtests.jl:11 [inlined]
   [16] macro expansion
      @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [17] top-level scope
      @ ~/Fudan/git/NiSparseArrays.jl/test/runtests.jl:11
   [18] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [19] top-level scope
      @ none:6
   [20] eval
      @ ./boot.jl:360 [inlined]
   [21] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [22] _start()
      @ Base ./client.jl:485
```
看不出来是哪个方法的问题...猜测可能和`getproperty`有关
参考实现代码：
[svd_rrule](https://github.com/JuliaDiff/ChainRules.jl/blob/master/src/rulesets/LinearAlgebra/factorization.jl#L216-L275)
我单独把这个文件中的`svd`的`getproperty`方法拿出来测试`rrule`，也无法通过...